### PR TITLE
feat: add Chrome extension

### DIFF
--- a/.github/workflows/chrome-extension.yml
+++ b/.github/workflows/chrome-extension.yml
@@ -1,0 +1,39 @@
+name: Chrome extension
+on:
+  pull_request:
+    paths: ['chrome-extension/**', 'web/auth/extension-challenge.*', '.github/workflows/chrome-extension.yml']
+  push:
+    branches: [main]
+    paths: ['chrome-extension/**', 'web/auth/extension-challenge.*', '.github/workflows/chrome-extension.yml']
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  test-and-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Unit and protocol tests
+        working-directory: chrome-extension
+        run: |
+          npm test
+          TZ=America/Los_Angeles npm test
+          TZ=Europe/Amsterdam npm test
+      - name: Package a validation-only build (no production credentials)
+        working-directory: chrome-extension
+        env:
+          SUPABASE_URL: https://api.example.test
+          SUPABASE_ANON_KEY: sb_publishable_validation_only
+          WEB_APP_URL: https://tasks.example.test
+        run: |
+          npm run build
+          cd dist
+          zip -r ../pomodoist-chrome-validation.zip .
+      - uses: actions/upload-artifact@v4
+        with:
+          name: chrome-extension-validation-build
+          path: chrome-extension/pomodoist-chrome-validation.zip
+          if-no-files-found: error

--- a/chrome-extension/.gitignore
+++ b/chrome-extension/.gitignore
@@ -1,0 +1,4 @@
+dist/
+*.zip
+__pycache__/
+test-output/

--- a/chrome-extension/PRIVACY.md
+++ b/chrome-extension/PRIVACY.md
@@ -11,11 +11,10 @@ status, tasks, project names, labels, completion history and workflow assignment
 to display and synchronize the same account used in other Pomodoist clients.
 A random device identifier and operation identifiers support synchronization.
 
-Choosing **Add current tab** reads only the active page's title and URL. It does
-not read page content or query browsing history. The URL, including any query or
-fragment it contains, is previewed before submission. Nothing is uploaded from
-that action until the user presses **Add**. The resulting title and URL are then
-ordinary task data synchronized to the user's configured account.
+Choosing **Add current tab** immediately creates a task from the active page's
+title and URL, including any query or fragment it contains, and synchronizes it
+to the user's configured account. It does not read page content or query browsing
+history.
 
 Passwords are sent to the configured authentication endpoint for sign-in and
 are not persisted. OAuth is handled by the selected identity provider. When

--- a/chrome-extension/PRIVACY.md
+++ b/chrome-extension/PRIVACY.md
@@ -1,0 +1,42 @@
+# Pomodoist Chrome extension: data handling
+
+This document describes the extension implementation. Before a store release,
+the operator must publish it with the applicable service privacy policy and
+support contact. The configured Pomodoist service governs server-side retention.
+
+## Information used
+
+The extension uses the account email, access/refresh tokens, account subscription
+status, tasks, project names, labels, completion history and workflow assignments
+to display and synchronize the same account used in other Pomodoist clients.
+A random device identifier and operation identifiers support synchronization.
+
+Choosing **Add current tab** reads only the active page's title and URL. It does
+not read page content or query browsing history. The URL, including any query or
+fragment it contains, is previewed before submission. Nothing is uploaded from
+that action until the user presses **Add**. The resulting title and URL are then
+ordinary task data synchronized to the user's configured account.
+
+Passwords are sent to the configured authentication endpoint for sign-in and
+are not persisted. OAuth is handled by the selected identity provider. When
+the server requires CAPTCHA, verification runs on the hosted Pomodoist web app
+using its configured Cloudflare Turnstile integration, not inside the extension.
+
+## Storage and network access
+
+Account tokens, a task cache and unsynced operations are kept in local Chrome
+extension storage, restricted to trusted extension contexts. They are not put in
+Chrome's cross-device `storage.sync`. The extension does not add its own encryption
+on top of browser/operating-system protection. Network synchronization uses the
+configured backend over HTTPS; HTTP is accepted only for loopback development.
+The extension contains no analytics, advertising or background browsing-history
+collection code and does not send task data to an additional extension service.
+
+## User control
+
+Sign-out clears local credentials, cached account data and, after explicit
+confirmation, unsynced changes. It requests revocation of this session only.
+It does not delete already-synchronized tasks from the shared service. Rebuilding
+for another backend resets the local account data, so synchronize first.
+Server-side deletion and account management remain available in the full app.
+Removing the extension removes its local extension storage.

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -7,7 +7,7 @@ Manifest V3 companion for Pomodoist. It uses the same Supabase Auth account, acc
 - Email/password and Google/Apple PKCE sign-in with token refresh.
 - Today (including overdue), Upcoming, Inbox and completed views.
 - Create, edit, schedule, complete and restore tasks.
-- Current-tab title/URL capture after an explicit click and review.
+- One-click task creation from the current tab's title and URL.
 - Durable local outbox, cursor-based pull, idempotent retries and remote tombstones.
 - Private Realtime hints while the popup is open, with a bounded refresh fallback.
 - Server-owned account and subscription/entitlement status.

--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -1,0 +1,62 @@
+# Pomodoist for Chrome
+
+Manifest V3 companion for Pomodoist. It uses the same Supabase Auth account, account overview and schema-v1 synchronization contract as the Flutter clients.
+
+## Included
+
+- Email/password and Google/Apple PKCE sign-in with token refresh.
+- Today (including overdue), Upcoming, Inbox and completed views.
+- Create, edit, schedule, complete and restore tasks.
+- Current-tab title/URL capture after an explicit click and review.
+- Durable local outbox, cursor-based pull, idempotent retries and remote tombstones.
+- Private Realtime hints while the popup is open, with a bounded refresh fallback.
+- Server-owned account and subscription/entitlement status.
+- Compact light/dark UI and keyboard-accessible task tabs.
+
+Recurring schedule metadata is preserved; recurrence rule management remains in the full app. Project moves, deletion, Focus, voice and billing also remain in the full app.
+
+## Build
+
+Node 22 or later is sufficient; the extension has no runtime npm dependencies.
+
+```sh
+cd chrome-extension
+export SUPABASE_URL='https://your-api.example.com'
+export SUPABASE_ANON_KEY='your-public-anon-or-sb_publishable-key'
+export WEB_APP_URL='https://your-web-app.example.com'
+export TURNSTILE_SITE_KEY=''
+npm test
+npm run build
+```
+
+Use a public `anon` JWT or `sb_publishable_...` key only. The builder rejects service-role/secret keys and insecure non-loopback origins. `dist/` can be loaded from `chrome://extensions` in Developer mode or zipped for Chrome Web Store validation.
+
+The build reuses `web/icons/Icon-192.png` and the repository `LICENSE`.
+
+## Authentication deployment
+
+For Google/Apple, add the real extension ID callback to the shared Supabase Auth allowlist:
+
+```text
+https://<extension-id>.chromiumapp.org/auth-callback*
+```
+
+When CAPTCHA is enabled, deploy `web/auth/extension-challenge.html` and `extension-challenge.js` with the web app. The page returns only a nonce-bound short-lived Turnstile token to Chrome's generated `/captcha-callback`; credentials and account tokens do not cross that page.
+
+## Security and performance
+
+Permissions are limited to `storage`, `identity`, `activeTab` and the configured backend origin. There are no content scripts, history permission, analytics, remote extension code, `eval`, or all-URL host permissions. Extension storage is limited to trusted contexts. The Realtime socket and 30-second fallback refresh run only while the popup is open; closing it stops those timers. Unsynced edits are durable and retry on the next open.
+
+See [PRIVACY.md](PRIVACY.md).
+
+## Chrome Web Store release checklist
+
+Source and packaging are prepared by this change, but publication is an operator action. Before closing the release portion of issue #22:
+
+1. Build against the production backend and deploy the CAPTCHA page if used.
+2. Add the published extension ID to the OAuth redirect allowlist and verify email/password, Google and Apple sign-in.
+3. Smoke-test two-way synchronization with an existing Pomodoist client and verify the same entitlement/subscription is reported.
+4. Publish the privacy disclosure and complete the Chrome Web Store single-purpose, permission and data-use declarations.
+5. Upload the production ZIP with the authorized publisher account and record the listing URL.
+
+No store upload, backend deployment or subscription purchase is performed by this source change.

--- a/chrome-extension/build.mjs
+++ b/chrome-extension/build.mjs
@@ -1,0 +1,57 @@
+import { mkdir, readFile, copyFile, writeFile, rm } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+const root = path.dirname(fileURLToPath(import.meta.url));
+function origin(value, name) {
+  let url;
+  try { url = new URL(value); } catch { throw new Error(`${name} must be configured with a valid origin.`); }
+  const loopback = ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname);
+  if ((url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) || url.username || url.password ||
+      url.search || url.hash || url.pathname !== '/') throw new Error(`${name} must be an HTTPS origin (HTTP is only allowed on loopback).`);
+  return url.origin;
+}
+export function configuration(env) {
+  const apiUrl = origin(env.SUPABASE_URL, 'SUPABASE_URL'), webUrl = origin(env.WEB_APP_URL, 'WEB_APP_URL');
+  const anonKey = env.SUPABASE_ANON_KEY?.trim() ?? '';
+  let publicKey = /^sb_publishable_[A-Za-z0-9_-]+$/.test(anonKey);
+  if (!publicKey) {
+    try { publicKey = anonKey.split('.').length === 3 && JSON.parse(Buffer.from(anonKey.split('.')[1], 'base64url')).role === 'anon'; }
+    catch { publicKey = false; }
+  }
+  if (!publicKey) throw new Error('SUPABASE_ANON_KEY must be a public anon/publishable key, never a service-role or secret key.');
+  return { apiUrl, webUrl, anonKey, captchaEnabled: !!env.TURNSTILE_SITE_KEY?.trim() };
+}
+export function manifestFor(config) {
+  const socket = new URL(config.apiUrl); socket.protocol = socket.protocol === 'https:' ? 'wss:' : 'ws:';
+  return { manifest_version: 3, name: 'Pomodoist', version: '0.1.0', minimum_chrome_version: '116',
+    description: 'Quick access to your Pomodoist tasks: Today, Upcoming, scheduling and browser tab capture.',
+    action: { default_popup: 'popup.html', default_title: 'Pomodoist', default_icon: 'icon.png' },
+    icons: { 16: 'icon.png', 32: 'icon.png', 48: 'icon.png', 128: 'icon.png' },
+    background: { service_worker: 'src/background.js', type: 'module' },
+    permissions: ['storage', 'identity', 'activeTab'], host_permissions: [`${config.apiUrl}/*`],
+    content_security_policy: { extension_pages: `default-src 'self'; script-src 'self'; object-src 'none'; style-src 'self'; img-src 'self'; connect-src ${config.apiUrl} ${socket.origin}; base-uri 'none'; form-action 'none'` },
+  };
+}
+export async function build(env = process.env) {
+  const config = configuration(env), destination = path.join(root, 'dist');
+  await rm(destination, { recursive: true, force: true });
+  await mkdir(path.join(destination, 'src'), { recursive: true });
+  for (const file of ['background.js', 'client.js', 'core.js', 'popup.js', 'realtime.js', 'sync.js']) {
+    await copyFile(path.join(root, 'src', file), path.join(destination, 'src', file));
+  }
+  for (const file of ['popup.html', 'styles.css']) await copyFile(path.join(root, file), path.join(destination, file));
+  // Reuse the application's existing branded PNG; Chrome scales it for toolbar sizes.
+  await copyFile(path.join(root, '../web/icons/Icon-192.png'), path.join(destination, 'icon.png'));
+  await copyFile(path.join(root, '../LICENSE'), path.join(destination, 'LICENSE'));
+  await writeFile(path.join(destination, 'manifest.json'), JSON.stringify(manifestFor(config), null, 2) + '\n');
+  await writeFile(path.join(destination, 'src/config.js'), `export const config = Object.freeze(${JSON.stringify(config, null, 2)});\n`);
+  await writeFile(path.join(destination, 'SOURCE.txt'), 'Pomodoist Chrome extension — AGPL-3.0-only\nSource and build instructions: https://github.com/Kabanya/Pomodoist/tree/' +
+    (env.GITHUB_SHA && /^[a-f0-9]{40}$/.test(env.GITHUB_SHA) ? env.GITHUB_SHA : 'main') + '/chrome-extension\n');
+  // Parse the emitted manifest, rather than reporting success after a partial write.
+  JSON.parse(await readFile(path.join(destination, 'manifest.json'), 'utf8'));
+  return destination;
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) {
+  try { console.log(`Built extension: ${await build()}`); }
+  catch (error) { console.error(error.message); process.exitCode = 1; }
+}

--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "pomodoist-chrome-extension",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "license": "AGPL-3.0-only",
+  "engines": { "node": ">=22" },
+  "scripts": { "test": "node --test test/*.test.js", "build": "node build.mjs" }
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="referrer" content="no-referrer"><title>Pomodoist</title>
+  <link rel="stylesheet" href="styles.css"><script type="module" src="src/popup.js"></script>
+</head>
+<body>
+  <header><strong>Pomodoist</strong><a id="open-app" target="_blank" rel="noopener noreferrer">Open app ↗</a></header>
+  <p id="error" role="alert" hidden></p>
+  <section id="auth" hidden>
+    <h1>Your tasks, one click away.</h1><p class="muted">Sign in with your existing Pomodoist account.</p>
+    <form id="login"><label>Email<input id="email" name="email" type="email" autocomplete="username" maxlength="320" required></label>
+      <label>Password<input id="password" name="password" type="password" autocomplete="current-password" maxlength="4096" required></label>
+      <button class="primary" type="submit">Sign in</button></form>
+    <div class="providers"><button id="google" type="button">Google</button><button id="apple" type="button">Apple</button></div>
+    <p class="muted small">Use the web app to create an account or reset your password. A verification window may open when signing in.</p>
+    <button id="clear-account" hidden type="button">Discard unsynced changes and sign out</button>
+  </section>
+  <main id="app" hidden>
+    <nav role="tablist" aria-label="Task lists">
+      <button role="tab" id="tab-today" data-view="today" aria-selected="true" aria-controls="task-panel">Today</button>
+      <button role="tab" id="tab-upcoming" data-view="upcoming" aria-selected="false" aria-controls="task-panel" tabindex="-1">Upcoming</button>
+      <button role="tab" id="tab-inbox" data-view="inbox" aria-selected="false" aria-controls="task-panel" tabindex="-1">Inbox</button>
+      <button role="tab" id="tab-completed" data-view="completed" aria-selected="false" aria-controls="task-panel" tabindex="-1">Done</button>
+    </nav>
+    <section id="task-panel" role="tabpanel" aria-labelledby="tab-today">
+      <form id="quick-add"><input id="new-title" aria-label="New task title" placeholder="Add a task…" maxlength="2048" required><button type="submit" class="primary">Add</button></form>
+      <div class="toolbar"><button id="save-tab" type="button">Add current tab</button><button id="refresh" type="button">Refresh</button></div>
+      <p id="tab-preview" class="small muted" hidden></p>
+      <div id="task-scroll"><ul id="tasks" aria-label="Tasks"></ul><p id="empty" class="muted" hidden>No tasks here.</p></div>
+    </section>
+    <section id="editor" hidden aria-labelledby="edit-heading">
+      <h2 id="edit-heading">Edit task</h2>
+      <form id="edit-form"><label>Title<input id="edit-title" maxlength="2048" required></label>
+        <label>Description<textarea id="edit-description" maxlength="8192" rows="2"></textarea></label>
+        <div class="schedule-grid"><label>Date<input id="edit-date" type="date"></label><label>Time<input id="edit-time" type="time"></label></div>
+        <div class="schedule-grid"><label>Duration (minutes)<input id="edit-minutes" type="number" min="1" max="10080" step="any" value="30"></label>
+          <label>Priority<select id="edit-priority"><option value="4">Normal</option><option value="3">Medium</option><option value="2">High</option><option value="1">Urgent</option></select></label></div>
+        <p id="recurrence-note" class="small muted" hidden>Existing recurrence is preserved. Manage recurrence rules in the full app.</p>
+        <div class="toolbar"><button id="clear-date" type="button">No date</button><span></span><button id="cancel-edit" type="button">Cancel</button><button class="primary" type="submit">Save</button></div>
+      </form>
+    </section>
+    <footer><div><span id="connection" role="status" aria-live="polite">Loading…</span><span id="account" class="small muted"></span></div><button id="logout" type="button">Sign out</button></footer>
+  </main>
+  <p id="startup" role="status" class="muted">Opening your tasks…</p>
+</body></html>

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -27,7 +27,6 @@
     <section id="task-panel" role="tabpanel" aria-labelledby="tab-today">
       <form id="quick-add"><input id="new-title" aria-label="New task title" placeholder="Add a task…" maxlength="2048" required><button type="submit" class="primary">Add</button></form>
       <div class="toolbar"><button id="save-tab" type="button">Add current tab</button><button id="refresh" type="button">Refresh</button></div>
-      <p id="tab-preview" class="small muted" hidden></p>
       <div id="task-scroll"><ul id="tasks" aria-label="Tasks"></ul><p id="empty" class="muted" hidden>No tasks here.</p></div>
     </section>
     <section id="editor" hidden aria-labelledby="edit-heading">

--- a/chrome-extension/src/background.js
+++ b/chrome-extension/src/background.js
@@ -1,0 +1,67 @@
+import { config } from './config.js';
+import { Store, synchronize } from './sync.js';
+import { Client } from './client.js';
+
+const store = new Store(chrome.storage.local, config.apiUrl);
+const ready = (async () => {
+  await chrome.storage.local.setAccessLevel({ accessLevel: 'TRUSTED_CONTEXTS' });
+  await store.init();
+})();
+const client = new Client(config, store);
+let tail = Promise.resolve();
+const notify = () => chrome.runtime.sendMessage({ event: 'state', snapshot: store.snapshot() }).catch(() => {});
+const sync = async () => { try { await synchronize(store, client, notify); } catch { /* Error is persisted and shown next time the popup opens. */ } };
+
+async function dispatch(message) {
+  const p = message.payload ?? {};
+  switch (message.type) {
+    case 'sync': await sync(); break;
+    case 'mutate': await store.enqueue(p.action, p.owner); notify(); await sync(); break;
+    case 'password': {
+      if (store.data.session) throw new Error('Sign out before switching accounts.');
+      if (typeof p.email !== 'string' || !p.email.trim() || p.email.length > 320 || typeof p.password !== 'string' || !p.password || p.password.length > 4096) {
+        throw new Error('Enter your email and password.');
+      }
+      const captcha = config.captchaEnabled ? await client.captcha(chrome.identity) : undefined;
+      await store.acceptSession(await client.password(p.email, p.password, captcha));
+      notify(); await sync(); break;
+    }
+    case 'oauth':
+      if (store.data.session) throw new Error('Sign out before switching accounts.');
+      await store.acceptSession(await client.oauth(p.provider, chrome.identity));
+      notify(); await sync(); break;
+    case 'logout': {
+      const token = store.data.session?.access_token;
+      await store.logout(p.discard === true); notify();
+      if (token) {
+        try { await client.raw('/auth/v1/logout?scope=local', {}, token, true); }
+        catch { await store.save({ error: 'Signed out on this device. Server session revocation could not be confirmed.' }); }
+      }
+      break;
+    }
+    case 'realtime':
+      return { apiUrl: config.apiUrl, anonKey: config.anonKey, accessToken: await client.token(),
+        userId: store.data.owner, deviceId: store.data.deviceId };
+    default: throw new Error('Unknown extension command.');
+  }
+  notify();
+  return store.snapshot();
+}
+chrome.runtime.onMessage.addListener((message, sender, respond) => {
+  if (message?.event) return false;
+  // No content scripts or external messaging. Only our packaged popup can read
+  // private account state or trigger an authenticated request.
+  if (sender.id !== chrome.runtime.id || sender.url !== chrome.runtime.getURL('popup.html')) return false;
+  if (message?.type === 'snapshot') {
+    ready.then(() => respond({ ok: true, value: store.snapshot() }), () => respond({ ok: false, error: 'Cannot open local extension storage.' }));
+    return true;
+  }
+  const run = tail.then(async () => { await ready; return dispatch(message); });
+  tail = run.catch(() => {});
+  run.then(value => respond({ ok: true, value }), async error => {
+    const message = error?.message || 'The operation failed. Please retry.';
+    if (store.data) { try { await store.save({ error: message }); notify(); } catch { /* Storage may be full. */ } }
+    respond({ ok: false, error: message });
+  });
+  return true;
+});

--- a/chrome-extension/src/client.js
+++ b/chrome-extension/src/client.js
@@ -15,7 +15,7 @@ class ApiError extends Error {
   }
 }
 export class Client {
-  constructor(config, store, fetcher = fetch) {
+  constructor(config, store, fetcher = fetch.bind(globalThis)) {
     this.config = config; this.store = store; this.fetcher = fetcher; this.refreshing = null;
   }
   async raw(path, body, token, auth = false) {
@@ -78,11 +78,12 @@ export class Client {
     return this.authorized(`/rest/v1/rpc/${name}`, body);
   }
   overview() { return this.rpc('get_account_overview'); }
-  broadcast() {
-    return this.authorized('/realtime/v1/api/broadcast', { messages: [{
+  async broadcast() {
+    // A rejected best-effort hint must not invalidate the Auth session.
+    return this.raw('/realtime/v1/api/broadcast', { messages: [{
       topic: `sync:${this.store.data.owner}:${APP_ID}`, event: 'changed', private: true,
       payload: { appId: APP_ID, deviceId: this.store.data.deviceId, sentAt: new Date().toISOString() },
-    }] });
+    }] }, await this.token());
   }
   async oauth(provider, identity) {
     if (!['google', 'apple'].includes(provider)) throw new Error('Unsupported sign-in provider.');

--- a/chrome-extension/src/client.js
+++ b/chrome-extension/src/client.js
@@ -1,0 +1,108 @@
+import { APP_ID, callbackValue } from './core.js';
+const b64url = bytes => btoa(String.fromCharCode(...bytes)).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '');
+export const nonce = () => b64url(crypto.getRandomValues(new Uint8Array(32)));
+export async function pkce() {
+  const verifier = nonce();
+  const challenge = b64url(new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier))));
+  return { verifier, challenge };
+}
+class ApiError extends Error {
+  constructor(status, auth) {
+    super(status === 401 ? 'Session expired. Sign in again.' : status === 403 ? 'The account is not permitted to perform this action.' :
+      status === 429 ? 'Too many requests. Wait briefly and retry.' : auth ? 'Sign-in failed. Check your credentials, verification and server configuration.' :
+        'Server request failed. Pending changes are kept; retry later.');
+    this.status = status;
+  }
+}
+export class Client {
+  constructor(config, store, fetcher = fetch) {
+    this.config = config; this.store = store; this.fetcher = fetcher; this.refreshing = null;
+  }
+  async raw(path, body, token, auth = false) {
+    let response;
+    try {
+      response = await this.fetcher(`${this.config.apiUrl}${path}`, {
+        method: 'POST', headers: { apikey: this.config.anonKey, 'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+        body: JSON.stringify(body), signal: AbortSignal.timeout(12000), redirect: 'error', credentials: 'omit', cache: 'no-store',
+      });
+    } catch { throw new Error('Cannot reach the server. Check your connection and retry.'); }
+    if (!response.ok) throw new ApiError(response.status, auth);
+    if (response.status === 204) return null;
+    const text = await response.text();
+    if (!text) return null;
+    try { return JSON.parse(text); } catch { throw new Error('Invalid server response.'); }
+  }
+  normalize(session) {
+    return { access_token: session.access_token, refresh_token: session.refresh_token,
+      expires_at: Number(session.expires_at ?? (Date.now() / 1000 + Number(session.expires_in))),
+      user: { id: session.user?.id, email: session.user?.email ?? '' } };
+  }
+  async password(email, password, captchaToken) {
+    const result = await this.raw('/auth/v1/token?grant_type=password', {
+      email: email.trim(), password, ...(captchaToken ? { gotrue_meta_security: { captcha_token: captchaToken } } : {}),
+    }, null, true);
+    return this.normalize(result);
+  }
+  async token(force = false) {
+    const session = this.store.data.session;
+    if (!session) throw new Error('Sign in to your Pomodoist account.');
+    if (!force && session.expires_at * 1000 > Date.now() + 60000) return session.access_token;
+    if (!this.refreshing) this.refreshing = this.refresh(session).finally(() => { this.refreshing = null; });
+    return this.refreshing;
+  }
+  async refresh(session) {
+    try {
+      const result = this.normalize(await this.raw('/auth/v1/token?grant_type=refresh_token', { refresh_token: session.refresh_token }, null, true));
+      if (result.user.id !== this.store.data.owner) throw new Error('Account changed during session refresh.');
+      await this.store.acceptSession(result);
+      return result.access_token;
+    } catch (error) {
+      if (error.status === 400 || error.status === 401) await this.store.save({ session: null, error: 'Session expired. Sign in again to sync pending changes.' });
+      throw error;
+    }
+  }
+  async authorized(path, body) {
+    try { return await this.raw(path, body, await this.token()); }
+    catch (error) {
+      if (error.status !== 401) throw error;
+      try { return await this.raw(path, body, await this.token(true)); }
+      catch (retryError) {
+        if (retryError.status === 401) await this.store.save({ session: null });
+        throw retryError;
+      }
+    }
+  }
+  rpc(name, body = {}) {
+    if (!['push_changes', 'pull_changes', 'get_account_overview'].includes(name)) throw new Error('Unsupported API call.');
+    return this.authorized(`/rest/v1/rpc/${name}`, body);
+  }
+  overview() { return this.rpc('get_account_overview'); }
+  broadcast() {
+    return this.authorized('/realtime/v1/api/broadcast', { messages: [{
+      topic: `sync:${this.store.data.owner}:${APP_ID}`, event: 'changed', private: true,
+      payload: { appId: APP_ID, deviceId: this.store.data.deviceId, sentAt: new Date().toISOString() },
+    }] });
+  }
+  async oauth(provider, identity) {
+    if (!['google', 'apple'].includes(provider)) throw new Error('Unsupported sign-in provider.');
+    const started = Date.now(), state = nonce(), { verifier, challenge } = await pkce();
+    const redirect = identity.getRedirectURL('auth-callback');
+    const target = new URL(redirect); target.searchParams.set('state', state);
+    const url = new URL(`${this.config.apiUrl}/auth/v1/authorize`);
+    url.search = new URLSearchParams({ provider, redirect_to: target.href, code_challenge: challenge, code_challenge_method: 's256' });
+    const result = await identity.launchWebAuthFlow({ url: url.href, interactive: true });
+    if (Date.now() - started > 10 * 60000) throw new Error('Sign-in expired. Please retry.');
+    const code = callbackValue(result, redirect, state, 'code');
+    return this.normalize(await this.raw('/auth/v1/token?grant_type=pkce', { auth_code: code, code_verifier: verifier }, null, true));
+  }
+  async captcha(identity) {
+    const started = Date.now(), state = nonce();
+    const redirect = identity.getRedirectURL('captcha-callback');
+    const url = new URL('/auth/extension-challenge.html', this.config.webUrl);
+    url.searchParams.set('returnTo', redirect); url.hash = new URLSearchParams({ state }).toString();
+    const result = await identity.launchWebAuthFlow({ url: url.href, interactive: true });
+    if (Date.now() - started > 5 * 60000) throw new Error('Verification expired. Please retry.');
+    return callbackValue(result, redirect, state, 'token');
+  }
+}

--- a/chrome-extension/src/core.js
+++ b/chrome-extension/src/core.js
@@ -1,0 +1,197 @@
+// The wire format follows app_account v0.2.0 and AccountSyncEngine (schema v1).
+export const APP_ID = 'pomodoist';
+const BACKLOG = 'kanban-status-backlog-v1';
+const DONE = 'kanban-status-done-v1';
+export const cachedTypes = new Set(['task', 'project', 'label', 'task_completion', 'task_kanban_status']);
+export const keyOf = (type, id) => `${type}:${id}`;
+export const recordsOf = (records, type) => Object.entries(records)
+  .filter(([key, row]) => key.startsWith(`${type}:`) && !row.isDeleted)
+  .map(([, row]) => row);
+export const dateKey = (date = new Date()) => [date.getFullYear(),
+  String(date.getMonth() + 1).padStart(2, '0'), String(date.getDate()).padStart(2, '0')].join('-');
+
+export function parseDue(raw) {
+  if (!raw) return null;
+  try {
+    const s = JSON.parse(raw);
+    if (s.type === 'allDay' && validDate(s.date)) return s;
+    if (s.type === 'timed' && Number.isFinite(Date.parse(s.start)) && Date.parse(s.end) > Date.parse(s.start)) return s;
+  } catch { /* Unknown schedules remain untouched until explicitly edited. */ }
+  return null;
+}
+function validDate(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const d = new Date(`${value}T12:00:00`);
+  return Number.isFinite(+d) && dateKey(d) === value;
+}
+export function dueDay(task) {
+  const s = parseDue(task.dueJson);
+  return !s ? '' : s.type === 'allDay' ? s.date : dateKey(new Date(s.start));
+}
+export function tasksFor(records, view, now = Date.now()) {
+  const today = dateKey(new Date(now));
+  return recordsOf(records, 'task').filter(task => {
+    const project = records[keyOf('project', task.projectId)];
+    if (project?.isDeleted || project?.isArchived) return false;
+    if (view === 'completed') return task.status === 'completed';
+    if (task.status !== 'open') return false;
+    const day = dueDay(task);
+    if (view === 'today') return day !== '' && day <= today;
+    if (view === 'upcoming') return day > today;
+    return task.projectId === 'inbox';
+  }).sort((a, b) => view === 'completed'
+    ? (new Date(b.completedAt).getTime() || 0) - (new Date(a.completedAt).getTime() || 0)
+    : dueDay(a).localeCompare(dueDay(b)) || (a.dayOrder ?? 0) - (b.dayOrder ?? 0) ||
+      String(a.orderKey).localeCompare(String(b.orderKey)) || a.id.localeCompare(b.id));
+}
+export function scheduleFields(raw) {
+  const s = parseDue(raw);
+  if (!s) return { date: '', time: '', minutes: 30 };
+  if (s.type === 'allDay') return { date: s.date, time: '', minutes: 30 };
+  const start = new Date(s.start);
+  return { date: dateKey(start), time: `${String(start.getHours()).padStart(2, '0')}:${String(start.getMinutes()).padStart(2, '0')}`,
+    minutes: (Date.parse(s.end) - +start) / 60000 };
+}
+export function schedule(date, time, minutes, previous) {
+  if (!date) {
+    if (parseDue(previous)?.recurrence) throw new Error('Remove repeating schedules in the full app.');
+    if (time) throw new Error('Choose a date before setting a time.');
+    return null;
+  }
+  if (!validDate(date)) throw new Error('Invalid calendar date.');
+  const old = parseDue(previous);
+  const metadata = {};
+  if (old?.recurrence) metadata.recurrence = old.recurrence;
+  if (old?.recurrenceSeriesId) metadata.recurrenceSeriesId = old.recurrenceSeriesId;
+  if (time === undefined && old?.type === 'timed') {
+    const start = new Date(old.start);
+    const [year, month, day] = date.split('-').map(Number);
+    start.setFullYear(year, month - 1, day);
+    return JSON.stringify({ ...old, start: start.toISOString(),
+      end: new Date(+start + Date.parse(old.end) - Date.parse(old.start)).toISOString() });
+  }
+  if (!time) return JSON.stringify({ type: 'allDay', date, ...metadata });
+  if (!/^([01]\d|2[0-3]):[0-5]\d$/.test(time)) throw new Error('Invalid time.');
+  if (!Number.isFinite(Number(minutes)) || minutes <= 0 || minutes > 10080) throw new Error('Duration must be between 1 and 10080 minutes.');
+  const start = new Date(`${date}T${time}:00`);
+  // Reject nonexistent wall times at a daylight-saving transition.
+  if (dateKey(start) !== date || start.getHours() !== Number(time.slice(0, 2)) || start.getMinutes() !== Number(time.slice(3))) {
+    throw new Error('This local time does not exist. Choose another time.');
+  }
+  return JSON.stringify({ type: 'timed', start: start.toISOString(),
+    end: new Date(+start + Number(minutes) * 60000).toISOString(),
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone, ...metadata });
+}
+function content(value) {
+  if (typeof value !== 'string' || !value.trim() || value.trim().length > 2048) throw new Error('Task title must contain 1–2048 characters.');
+  return value.trim();
+}
+function checkedDue(raw) {
+  if (raw === null) return null;
+  if (typeof raw !== 'string' || raw.length > 16384 || !parseDue(raw)) throw new Error('Invalid schedule.');
+  return raw;
+}
+function statusBefore(records, id) {
+  const labelId = records[keyOf('task_kanban_status', id)]?.labelId;
+  return validStatus(records, labelId) ? labelId : BACKLOG;
+}
+function validStatus(records, id) {
+  const label = records[keyOf('label', id)];
+  return id === BACKLOG || (label && !label.isDeleted && label.kind === 'kanbanStatus' && label.systemKey !== 'done');
+}
+function restoreStatus(records, id) {
+  for (const completion of recordsOf(records, 'task_completion').filter(c => c.taskId === id)
+    .sort((a, b) => new Date(b.completedAt) - new Date(a.completedAt))) {
+    try {
+      const snapshot = JSON.parse(completion.snapshotJson);
+      const status = snapshot?.version === 1 && snapshot.kanban?.previousStatusLabelId;
+      if (status && validStatus(records, status)) return status;
+    } catch { /* Older completion records may not contain a workflow snapshot. */ }
+  }
+  return BACKLOG;
+}
+export function taskOperations(records, action, now = Date.now(), uuid = () => crypto.randomUUID()) {
+  const iso = new Date(now).toISOString();
+  const op = (entityType, entityId, payload, commandType) => ({ opId: uuid(), entityType, entityId,
+    operation: 'upsert', payload: { schemaVersion: 1, ...(commandType ? { commandType } : {}), ...payload }, clientUpdatedAt: iso });
+  const status = (id, labelId) => op('task_kanban_status', id, { taskId: id, labelId, changedAt: iso }, 'task.kanbanStatus.set');
+  if (action.kind === 'create') {
+    const id = uuid();
+    const dueJson = checkedDue(action.dueJson ?? null);
+    const description = action.description ?? null;
+    if (description !== null && (typeof description !== 'string' || description.length > 8192)) throw new Error('Description is too long.');
+    const row = { id, userId: 'local-user', content: content(action.content), description,
+      projectId: 'inbox', sectionId: null, parentId: null, priority: 4, dueJson, deadlineJson: null,
+      durationSeconds: parseDue(dueJson)?.type === 'timed' ? (Date.parse(parseDue(dueJson).end) - Date.parse(parseDue(dueJson).start)) / 1000 : null,
+      status: 'open', estimatedFocusIntervals: null, completedFocusIntervals: 0, totalFocusSeconds: 0,
+      orderKey: String(now * 1000).padStart(20, '0'), dayOrder: null, isCollapsed: false, isDeleted: false,
+      createdAt: now, updatedAt: now, completedAt: null };
+    return [op('task', id, row, 'task.create'), status(id, BACKLOG)];
+  }
+  const task = records[keyOf('task', action.id)];
+  if (!task || task.isDeleted) throw new Error('Task is no longer available. Refresh the list.');
+  if (action.kind === 'edit') {
+    const patch = {};
+    if (!action.patch || Array.isArray(action.patch)) throw new Error('Invalid task edit.');
+    for (const [key, value] of Object.entries(action.patch)) {
+      if (key === 'content') patch.content = content(value);
+      else if (key === 'description' && (value === null || (typeof value === 'string' && value.length <= 8192))) patch.description = value;
+      else if (key === 'priority' && Number.isInteger(value) && value >= 1 && value <= 4) patch.priority = value;
+      else if (key === 'dueJson') {
+        patch.dueJson = checkedDue(value);
+        const s = parseDue(value);
+        patch.durationSeconds = s?.type === 'timed' ? (Date.parse(s.end) - Date.parse(s.start)) / 1000 : null;
+      } else throw new Error('Unsupported task field.');
+    }
+    if (!Object.keys(patch).length) return [];
+    return [op('task', task.id, { id: task.id, ...patch, updatedAt: now }, 'task.update')];
+  }
+  if (!['complete', 'uncomplete'].includes(action.kind)) throw new Error('Unknown task action.');
+  const tasks = recordsOf(records, 'task');
+  const stack = [task], seen = new Set(), operations = [];
+  while (stack.length) {
+    const row = stack.pop();
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    stack.push(...tasks.filter(child => child.parentId === row.id));
+    const completing = action.kind === 'complete';
+    if ((row.status === 'completed') === completing) continue;
+    operations.push(op('task', row.id, { id: row.id, status: completing ? 'completed' : 'open',
+      completedAt: completing ? iso : null, updatedAt: now }, `task.${action.kind}`));
+    if (completing) {
+      const completionId = uuid();
+      operations.push(op('task_completion', completionId, { id: completionId, taskId: row.id, userId: 'local-user',
+        completedAt: now, createdAt: now, snapshotJson: JSON.stringify({ version: 1, kanban: { previousStatusLabelId: statusBefore(records, row.id) } }) }));
+    }
+    operations.push(status(row.id, completing ? DONE : restoreStatus(records, row.id)));
+  }
+  return operations;
+}
+export function optimisticRecords(records, operations) {
+  const next = { ...records };
+  for (const op of operations) {
+    const key = keyOf(op.entityType, op.entityId);
+    if (!cachedTypes.has(op.entityType)) continue;
+    if (op.operation === 'delete') delete next[key];
+    else next[key] = { ...next[key], ...op.payload, id: op.entityId };
+  }
+  return next;
+}
+export function tabDraft(tab) {
+  let url;
+  try { url = new URL(tab?.url); } catch { throw new Error('This tab cannot be saved.'); }
+  if (!['https:', 'http:'].includes(url.protocol) || url.username || url.password) throw new Error('Only ordinary HTTP(S) pages can be saved.');
+  if (url.href.length > 8192) throw new Error('This page URL is too long to save.');
+  return { content: (tab.title?.trim() || url.hostname).slice(0, 512), description: url.href };
+}
+export function callbackValue(raw, redirect, state, name) {
+  let url;
+  try { url = new URL(raw); } catch { throw new Error('Sign-in was cancelled.'); }
+  const expected = new URL(redirect);
+  if (url.origin !== expected.origin || url.pathname !== expected.pathname || url.username || url.password || url.hash ||
+      url.searchParams.getAll('state').length !== 1 || url.searchParams.get('state') !== state ||
+      url.searchParams.getAll(name).length !== 1) throw new Error('Invalid sign-in callback. Please retry.');
+  const value = url.searchParams.get(name);
+  if (!value || value.length > 2048 || /[\u0000-\u001f\u007f-\u009f]/.test(value)) throw new Error('Invalid sign-in response.');
+  return value;
+}

--- a/chrome-extension/src/popup.js
+++ b/chrome-extension/src/popup.js
@@ -1,0 +1,178 @@
+import { config } from './config.js';
+import { dateKey, dueDay, parseDue, schedule, scheduleFields, tabDraft, tasksFor } from './core.js';
+import { Realtime } from './realtime.js';
+const $ = id => document.getElementById(id);
+let state, view = 'today', editing = null, dirty = new Set(), draftDescription = '', busy = 0, live = false, syncing = false;
+let owner = null, poll, hintTimer, refreshAgain = false;
+const realtime = new Realtime(() => call('realtime'), () => {
+  clearTimeout(hintTimer); hintTimer = setTimeout(refresh, 150);
+}, connected => { live = connected; status(); });
+$('open-app').href = config.webUrl;
+async function call(type, payload = {}) {
+  const result = await chrome.runtime.sendMessage({ type, payload });
+  if (!result?.ok) throw new Error(result?.error || 'The extension did not respond. Reopen it and retry.');
+  return result.value;
+}
+function error(message = '') { $('error').textContent = message; $('error').hidden = !message; }
+function lock() {
+  for (const element of document.querySelectorAll('button,input,select,textarea')) element.disabled = busy > 0;
+}
+async function run(action) {
+  busy++; lock(); error('');
+  try { await action(); } catch (e) { error(e.message); }
+  finally { busy--; lock(); }
+}
+function status() {
+  if (!state?.user) return;
+  const pending = state.pending;
+  $('connection').textContent = pending ? `${pending} changes saved locally · waiting to sync` : syncing ? 'Syncing…' :
+    state.error ? 'Offline or sync needs attention' : state.lastSyncedAt ? (live ? 'Live sync' : 'Synced · periodic refresh') : 'Loading account data…';
+  const overview = state.overview, profile = overview?.profile;
+  const app = overview?.apps?.find(item => (item.id ?? item.appId ?? item.app_id) === 'pomodoist');
+  let plan = 'Plan unavailable';
+  if (profile) {
+    const active = app?.entitlements?.some(item => item.status === 'active' &&
+      (!(item.validUntil ?? item.valid_until) || new Date(item.validUntil ?? item.valid_until).getTime() > Date.now()));
+    plan = (profile.pomodoistIsPro ?? profile.pomodoist_is_pro) ? 'Pro' : active ? 'Account access active' : 'Free';
+    if (Date.now() - state.overviewAt > 90000) plan += ' (cached)';
+  }
+  $('account').textContent = `${state.user.email} · ${plan}`;
+  $('account').title = state.overviewAt ? `Account status checked ${new Date(state.overviewAt).toLocaleString()}` : 'Account status has not been loaded.';
+}
+function render(next) {
+  const previousOwner = owner;
+  state = next; owner = state.user?.id ?? null;
+  $('startup').hidden = true; $('auth').hidden = !!owner; $('app').hidden = !owner;
+  $('clear-account').hidden = !!owner || !state.pending;
+  if (previousOwner !== owner) {
+    editing = null; $('editor').hidden = true; $('task-panel').hidden = false;
+    $('new-title').value = ''; draftDescription = ''; $('tab-preview').hidden = true;
+    realtime.stop(); clearInterval(poll);
+    if (owner) { realtime.start(); poll = setInterval(refresh, 30000); }
+  }
+  error(state.error);
+  if (!owner) return;
+  status();
+  const scroll = $('task-scroll').scrollTop;
+  const focusId = document.activeElement?.dataset.taskId;
+  const rows = tasksFor(state.records, view);
+  const fragment = document.createDocumentFragment();
+  for (const task of rows) {
+    const li = document.createElement('li'); li.className = `task${task.status === 'completed' ? ' completed' : ''}`;
+    const check = document.createElement('input'); check.type = 'checkbox'; check.checked = task.status === 'completed';
+    check.disabled = busy > 0; check.dataset.taskId = task.id;
+    check.setAttribute('aria-label', `${check.checked ? 'Restore' : 'Complete'} ${task.content}`);
+    check.addEventListener('change', () => run(async () => render(await call('mutate', { owner, action: {
+      kind: check.checked ? 'complete' : 'uncomplete', id: task.id,
+    } }))));
+    const edit = document.createElement('button'); edit.type = 'button'; edit.className = 'task-edit'; edit.disabled = busy > 0;
+    const title = document.createElement('span'); title.className = 'task-title'; title.textContent = task.content;
+    const meta = document.createElement('span'); meta.className = 'task-meta';
+    const due = parseDue(task.dueJson), date = dueDay(task);
+    const parts = [];
+    if (date) parts.push(date + (due?.type === 'timed' ? ` · ${new Date(due.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}` : ''));
+    if (due?.recurrence || due?.recurrenceSeriesId) parts.push('Repeating');
+    if (task.parentId) parts.push('Subtask');
+    if (task.projectId !== 'inbox') parts.push(state.records[`project:${task.projectId}`]?.name || 'Project');
+    if (task.priority < 4) parts.push(`P${task.priority}`);
+    meta.textContent = parts.join(' · ');
+    if (date && date < dateKey() && task.status !== 'completed') meta.classList.add('overdue');
+    edit.append(title, meta); edit.addEventListener('click', () => openEditor(task));
+    li.append(check, edit); fragment.append(li);
+  }
+  $('tasks').replaceChildren(fragment); $('empty').hidden = rows.length > 0; $('task-scroll').scrollTop = scroll;
+  if (focusId) [...$('tasks').querySelectorAll('input')].find(el => el.dataset.taskId === focusId)?.focus({ preventScroll: true });
+}
+async function refresh() {
+  if (!state?.user || document.hidden) return;
+  if (syncing) { refreshAgain = true; return; }
+  syncing = true; status();
+  try { render(await call('sync')); } catch (e) { error(e.message); }
+  finally {
+    syncing = false; status();
+    if (refreshAgain) { refreshAgain = false; queueMicrotask(refresh); }
+  }
+}
+function openEditor(task) {
+  editing = task; dirty = new Set();
+  const fields = scheduleFields(task.dueJson);
+  $('edit-title').value = task.content; $('edit-description').value = task.description || '';
+  $('edit-date').value = fields.date; $('edit-time').value = fields.time; $('edit-minutes').value = fields.minutes;
+  $('edit-priority').value = task.priority ?? 4;
+  const due = parseDue(task.dueJson);
+  $('recurrence-note').hidden = !due?.recurrence && !due?.recurrenceSeriesId;
+  $('task-panel').hidden = true; $('editor').hidden = false; $('edit-title').focus();
+}
+function closeEditor() { editing = null; $('editor').hidden = true; $('task-panel').hidden = false; }
+for (const id of ['edit-date', 'edit-time', 'edit-minutes']) $(id).addEventListener('input', () => dirty.add(id));
+$('cancel-edit').addEventListener('click', closeEditor);
+$('clear-date').addEventListener('click', () => {
+  $('edit-date').value = ''; $('edit-time').value = ''; dirty.add('edit-date'); dirty.add('edit-time');
+});
+$('edit-form').addEventListener('submit', event => {
+  event.preventDefault();
+  run(async () => {
+    const patch = {};
+    if ($('edit-title').value.trim() !== editing.content) patch.content = $('edit-title').value;
+    if ($('edit-description').value !== (editing.description || '')) patch.description = $('edit-description').value || null;
+    if (Number($('edit-priority').value) !== editing.priority) patch.priority = Number($('edit-priority').value);
+    if (dirty.size) {
+      const dateOnly = dirty.size === 1 && dirty.has('edit-date');
+      patch.dueJson = schedule($('edit-date').value, dateOnly ? undefined : $('edit-time').value,
+        dateOnly ? undefined : Number($('edit-minutes').value), editing.dueJson);
+    }
+    const result = await call('mutate', { owner, action: { kind: 'edit', id: editing.id, patch } });
+    closeEditor(); render(result);
+  });
+});
+$('quick-add').addEventListener('submit', event => {
+  event.preventDefault();
+  run(async () => {
+    const result = await call('mutate', { owner, action: { kind: 'create', content: $('new-title').value,
+      description: draftDescription || null, dueJson: view === 'today' ? schedule(dateKey(), '', 30, null) : null } });
+    $('new-title').value = ''; draftDescription = ''; $('tab-preview').hidden = true; render(result);
+  });
+});
+$('save-tab').addEventListener('click', () => run(async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const draft = tabDraft(tab); $('new-title').value = draft.content; draftDescription = draft.description;
+  $('tab-preview').textContent = `${draft.description} — review, then press Add to save.`; $('tab-preview').hidden = false;
+}));
+for (const tab of document.querySelectorAll('[data-view]')) {
+  tab.addEventListener('click', () => {
+    view = tab.dataset.view; closeEditor();
+    for (const item of document.querySelectorAll('[data-view]')) { item.setAttribute('aria-selected', String(item === tab)); item.tabIndex = item === tab ? 0 : -1; }
+    $('task-panel').setAttribute('aria-labelledby', tab.id); $('task-scroll').scrollTop = 0; render(state);
+  });
+  tab.addEventListener('keydown', event => {
+    const tabs = [...document.querySelectorAll('[data-view]')]; let index = tabs.indexOf(tab);
+    if (event.key === 'ArrowRight') index = (index + 1) % tabs.length;
+    else if (event.key === 'ArrowLeft') index = (index + tabs.length - 1) % tabs.length;
+    else return;
+    event.preventDefault(); tabs[index].click(); tabs[index].focus();
+  });
+}
+$('refresh').addEventListener('click', refresh);
+$('login').addEventListener('submit', event => {
+  event.preventDefault();
+  const credentials = { email: $('email').value, password: $('password').value }; $('password').value = '';
+  run(async () => render(await call('password', credentials)));
+});
+for (const provider of ['google', 'apple']) $(provider).addEventListener('click', () => run(async () => render(await call('oauth', { provider }))));
+async function logout() {
+  const discard = state.pending > 0;
+  if (discard && !confirm('There are unsynced changes. Signing out will discard them on this device. Continue?')) return;
+  realtime.stop(); clearInterval(poll);
+  render(await call('logout', { discard }));
+}
+$('logout').addEventListener('click', () => run(logout));
+$('clear-account').addEventListener('click', () => run(logout));
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (sender.id === chrome.runtime.id && message?.event === 'state' && message.snapshot) render(message.snapshot);
+});
+window.addEventListener('online', refresh);
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) realtime.stop(); else if (state?.user) { realtime.start(); refresh(); }
+});
+window.addEventListener('pagehide', () => { realtime.stop(); clearInterval(poll); clearTimeout(hintTimer); });
+try { render(await call('snapshot')); refresh(); } catch (e) { $('startup').hidden = true; error(e.message); }

--- a/chrome-extension/src/popup.js
+++ b/chrome-extension/src/popup.js
@@ -2,7 +2,7 @@ import { config } from './config.js';
 import { dateKey, dueDay, parseDue, schedule, scheduleFields, tabDraft, tasksFor } from './core.js';
 import { Realtime } from './realtime.js';
 const $ = id => document.getElementById(id);
-let state, view = 'today', editing = null, dirty = new Set(), draftDescription = '', busy = 0, live = false, syncing = false;
+let state, view = 'today', editing = null, dirty = new Set(), busy = 0, live = false, syncing = false;
 let owner = null, poll, hintTimer, refreshAgain = false;
 const realtime = new Realtime(() => call('realtime'), () => {
   clearTimeout(hintTimer); hintTimer = setTimeout(refresh, 150);
@@ -46,7 +46,7 @@ function render(next) {
   $('clear-account').hidden = !!owner || !state.pending;
   if (previousOwner !== owner) {
     editing = null; $('editor').hidden = true; $('task-panel').hidden = false;
-    $('new-title').value = ''; draftDescription = ''; $('tab-preview').hidden = true;
+    $('new-title').value = '';
     realtime.stop(); clearInterval(poll);
     if (owner) { realtime.start(); poll = setInterval(refresh, 30000); }
   }
@@ -129,14 +129,14 @@ $('quick-add').addEventListener('submit', event => {
   event.preventDefault();
   run(async () => {
     const result = await call('mutate', { owner, action: { kind: 'create', content: $('new-title').value,
-      description: draftDescription || null, dueJson: view === 'today' ? schedule(dateKey(), '', 30, null) : null } });
-    $('new-title').value = ''; draftDescription = ''; $('tab-preview').hidden = true; render(result);
+      description: null, dueJson: view === 'today' ? schedule(dateKey(), '', 30, null) : null } });
+    $('new-title').value = ''; render(result);
   });
 });
 $('save-tab').addEventListener('click', () => run(async () => {
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  const draft = tabDraft(tab); $('new-title').value = draft.content; draftDescription = draft.description;
-  $('tab-preview').textContent = `${draft.description} — review, then press Add to save.`; $('tab-preview').hidden = false;
+  render(await call('mutate', { owner, action: { kind: 'create', ...tabDraft(tab),
+    dueJson: view === 'today' ? schedule(dateKey(), '', 30, null) : null } }));
 }));
 for (const tab of document.querySelectorAll('[data-view]')) {
   tab.addEventListener('click', () => {

--- a/chrome-extension/src/realtime.js
+++ b/chrome-extension/src/realtime.js
@@ -1,0 +1,72 @@
+// Realtime is only active while the popup is open. The worker has no timers or
+// persistent socket. Polling in the popup remains a bounded fallback.
+export class Realtime {
+  constructor(getContext, changed, status, Socket = WebSocket) {
+    this.getContext = getContext; this.changed = changed; this.status = status; this.Socket = Socket;
+    this.stopped = true; this.attempt = 0; this.generation = 0; this.ref = 0;
+  }
+  start() { if (!this.stopped) return; this.stopped = false; this.connect(); }
+  stop() {
+    this.stopped = true; this.generation++; this.cleanup(); this.status(false);
+  }
+  cleanup() {
+    clearTimeout(this.retry); clearTimeout(this.joinTimeout); clearInterval(this.heartbeat); clearInterval(this.authTimer);
+    const socket = this.socket; this.socket = null;
+    if (socket) { socket.onclose = null; socket.onerror = null; socket.onmessage = null; socket.onopen = null; socket.close(); }
+  }
+  send(event, payload, topic = this.topic, ref = String(++this.ref)) {
+    if (this.socket?.readyState === 1) this.socket.send(JSON.stringify({ topic, event, payload, ref, ...(topic !== 'phoenix' ? { join_ref: this.joinRef } : {}) }));
+    return ref;
+  }
+  reconnect(generation) {
+    if (this.stopped || generation !== this.generation) return;
+    this.generation++; this.cleanup(); this.status(false);
+    this.retry = setTimeout(() => this.connect(), Math.min(30000, 1000 * 2 ** Math.min(this.attempt++, 5)));
+  }
+  async connect() {
+    if (this.stopped) return;
+    const generation = ++this.generation;
+    try {
+      const ctx = await this.getContext();
+      if (this.stopped || generation !== this.generation) return;
+      const url = new URL(`${ctx.apiUrl}/realtime/v1/websocket`);
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+      url.search = new URLSearchParams({ apikey: ctx.anonKey, vsn: '1.0.0' });
+      this.topic = `realtime:sync:${ctx.userId}:pomodoist`; this.userId = ctx.userId;
+      this.token = ctx.accessToken; this.joinRef = String(++this.ref); this.pendingHeartbeat = null;
+      const socket = this.socket = new this.Socket(url.href);
+      socket.onopen = () => {
+        this.send('phx_join', { config: { private: true, broadcast: { ack: false, self: false },
+          presence: { enabled: false }, postgres_changes: [] }, access_token: ctx.accessToken }, this.topic, this.joinRef);
+      };
+      this.joinTimeout = setTimeout(() => this.reconnect(generation), 12000);
+      socket.onmessage = event => {
+        if (generation !== this.generation) return;
+        let frame; try { frame = JSON.parse(event.data); } catch { return; }
+        if (frame.topic === 'phoenix' && frame.event === 'phx_reply' && frame.ref === this.pendingHeartbeat) this.pendingHeartbeat = null;
+        if (frame.topic !== this.topic) return;
+        if (frame.event === 'phx_reply' && frame.ref === this.joinRef) {
+          if (frame.payload?.status !== 'ok') { this.reconnect(generation); return; }
+          clearTimeout(this.joinTimeout); this.attempt = 0; this.status(true); this.changed();
+          clearInterval(this.heartbeat);
+          this.heartbeat = setInterval(() => {
+            if (this.pendingHeartbeat) { this.reconnect(generation); return; }
+            this.pendingHeartbeat = this.send('heartbeat', {}, 'phoenix');
+          }, 25000);
+          clearInterval(this.authTimer);
+          this.authTimer = setInterval(async () => {
+            try {
+              const current = await this.getContext();
+              if (generation !== this.generation) return;
+              if (current.userId !== this.userId) { this.reconnect(generation); return; }
+              if (current.accessToken !== this.token) { this.token = current.accessToken; this.send('access_token', { access_token: this.token }); }
+            } catch { this.reconnect(generation); }
+          }, 30000);
+        } else if (frame.event === 'broadcast' && frame.payload?.event === 'changed' &&
+                   frame.payload?.payload?.appId === 'pomodoist' && frame.payload.payload.deviceId !== ctx.deviceId) this.changed();
+        else if (['phx_error', 'phx_close'].includes(frame.event) || (frame.event === 'system' && frame.payload?.status === 'error')) this.reconnect(generation);
+      };
+      socket.onerror = socket.onclose = () => this.reconnect(generation);
+    } catch { this.reconnect(generation); }
+  }
+}

--- a/chrome-extension/src/sync.js
+++ b/chrome-extension/src/sync.js
@@ -1,0 +1,118 @@
+import { APP_ID, cachedTypes, keyOf, optimisticRecords, taskOperations } from './core.js';
+const STORAGE_KEY = 'pomodoist-extension-v1';
+const fresh = instance => ({ version: 1, instance, deviceId: crypto.randomUUID(), owner: null,
+  session: null, records: {}, cursor: 0, outbox: [], overview: null, overviewAt: 0, lastSyncedAt: 0, error: '' });
+
+// All writes run through the service worker's serial queue. One storage item
+// commits the outbox, cache and cursor together, including after worker restarts.
+export class Store {
+  constructor(storage, instance) { this.storage = storage; this.instance = instance; }
+  async init() {
+    const saved = (await this.storage.get(STORAGE_KEY))[STORAGE_KEY];
+    this.data = saved?.version === 1 && saved.instance === this.instance ? saved : fresh(this.instance);
+    if (this.data !== saved) await this.storage.set({ [STORAGE_KEY]: this.data });
+  }
+  async save(patch) {
+    const next = { ...this.data, ...patch };
+    await this.storage.set({ [STORAGE_KEY]: next });
+    this.data = next;
+  }
+  async acceptSession(session) {
+    if (!session?.user?.id || !session.access_token || !session.refresh_token || !Number.isFinite(session.expires_at)) {
+      throw new Error('The server returned an invalid session.');
+    }
+    const owner = session.user.id;
+    if (this.data.owner !== owner && this.data.outbox.length) throw new Error('Unsynced tasks belong to another account. Sign out explicitly to discard them first.');
+    const state = this.data.owner === owner ? this.data : fresh(this.instance);
+    await this.save({ ...state, session, owner, error: '' });
+  }
+  async logout(discardPending = false) {
+    if (this.data.outbox.length && !discardPending) throw new Error('Unsynced changes remain. Sync first or confirm discarding them.');
+    await this.save(fresh(this.instance));
+  }
+  snapshot() {
+    const session = this.data.session;
+    return { user: session ? { id: this.data.owner, email: session.user.email ?? '' } : null,
+      records: session ? optimisticRecords(this.data.records, this.data.outbox) : {},
+      pending: this.data.outbox.length, overview: session ? this.data.overview : null,
+      overviewAt: this.data.overviewAt, lastSyncedAt: this.data.lastSyncedAt, error: this.data.error };
+  }
+  async enqueue(action, expectedOwner) {
+    if (!this.data.session || expectedOwner !== this.data.owner) throw new Error('Account changed. Reopen the extension before editing.');
+    const operations = taskOperations(this.snapshot().records, action);
+    if (this.data.outbox.length + operations.length > 5000) throw new Error('Too many pending changes. Sync before adding more.');
+    await this.save({ outbox: [...this.data.outbox, ...operations], error: '' });
+  }
+}
+function apply(records, changes) {
+  const next = { ...records };
+  for (const entity of changes) {
+    const type = entity.entityType ?? entity.entity_type;
+    const id = entity.entityId ?? entity.entity_id;
+    if (typeof type !== 'string' || typeof id !== 'string' || !id) throw new Error('Invalid sync response.');
+    if (!cachedTypes.has(type)) continue;
+    if (entity.deletedAt ?? entity.deleted_at) next[keyOf(type, id)] = { id, isDeleted: true };
+    else {
+      if (!entity.data || typeof entity.data !== 'object' || Array.isArray(entity.data)) throw new Error('Invalid sync response.');
+      next[keyOf(type, id)] = { ...entity.data, id };
+    }
+  }
+  return next;
+}
+export async function synchronize(store, client, changed = () => {}) {
+  if (!store.data.session) return;
+  try {
+    let pushed = false;
+    // Limits are per activation; subsequent syncs resume from the durable cursor.
+    for (let batch = 0; store.data.outbox.length && batch < 50; batch++) {
+      const operations = store.data.outbox.slice(0, 100);
+      const result = await client.rpc('push_changes', { p_app_id: APP_ID,
+        p_device_id: store.data.deviceId, p_operations: operations });
+      if (!result || !Array.isArray(result.applied) || !Number.isSafeInteger(Number(result.serverRevision ?? result.server_revision))) {
+        throw new Error('Invalid push response. Pending changes were kept.');
+      }
+      const acknowledged = new Set(operations.map(op => op.opId));
+      await store.save({ records: apply(store.data.records, result.applied),
+        outbox: store.data.outbox.filter(op => !acknowledged.has(op.opId)) });
+      // Never use the push revision as the pull cursor: it skips other devices.
+      pushed = true; changed();
+    }
+    let resets = 0;
+    for (let page = 0; ; page++) {
+      if (page >= 50) throw new Error('More history is available. Press Refresh to continue syncing.');
+      const since = store.data.cursor;
+      const result = await client.rpc('pull_changes', { p_app_id: APP_ID,
+        p_device_id: store.data.deviceId, p_since_revision: since, p_limit: 500 });
+      const cursor = Number(result?.nextCursor ?? result?.next_cursor);
+      const hasMore = result?.hasMore ?? result?.has_more;
+      if (!Number.isSafeInteger(cursor) || cursor < 0 || typeof hasMore !== 'boolean' || !Array.isArray(result?.changes)) {
+        throw new Error('Invalid pull response. Cached changes were kept.');
+      }
+      if (cursor < since) {
+        if (++resets > 1) throw new Error('Server cursor keeps resetting. Retry later.');
+        await store.save({ records: {}, cursor: 0 });
+        continue;
+      }
+      if (hasMore && cursor <= since) throw new Error('Server cursor did not advance. Retry later.');
+      await store.save({ records: apply(store.data.records, result.changes), cursor });
+      changed();
+      if (!hasMore) break;
+    }
+    if (pushed) {
+      try { await client.broadcast(); } catch { /* Durable sync succeeded; a hint is only an accelerator. */ }
+    }
+    if (Date.now() - store.data.overviewAt > 60000) {
+      try { await store.save({ overview: await client.overview(), overviewAt: Date.now() }); }
+      catch (error) {
+        if (!store.data.session) throw error;
+        // Keep the prior overview's timestamp; the popup labels stale status.
+      }
+    }
+    await store.save({ error: '', lastSyncedAt: Date.now() });
+    changed();
+  } catch (error) {
+    await store.save({ error: error.message || 'Sync failed. Retry when online.' });
+    changed();
+    throw error;
+  }
+}

--- a/chrome-extension/styles.css
+++ b/chrome-extension/styles.css
@@ -15,7 +15,6 @@ p { margin:10px 0; } .muted { color:var(--muted); } .small { font-size:11px; } #
 nav { display:flex; gap:4px; border-bottom:1px solid var(--line); margin-bottom:12px; padding-bottom:10px; } nav button { border:0; padding:7px 10px; color:var(--muted); } nav [aria-selected=true] { background:var(--soft); color:var(--accent); font-weight:650; }
 #quick-add { display:flex; gap:8px; } #quick-add input { flex:1; }
 .toolbar { display:flex; align-items:center; gap:6px; margin:10px 0; } .toolbar>span { flex:1; } .toolbar button { font-size:12px; } #refresh { margin-left:auto; }
-#tab-preview { overflow-wrap:anywhere; padding:8px; background:var(--soft); border-radius:6px; }
 #task-scroll { max-height:300px; overflow:auto; scrollbar-gutter:stable; } ul { list-style:none; padding:0; margin:0; }
 .task { display:flex; align-items:flex-start; gap:8px; padding:10px 2px; border-bottom:1px solid var(--line); }
 .task input { flex:none; width:17px; height:17px; margin:3px 0 0; accent-color:var(--accent); cursor:pointer; }

--- a/chrome-extension/styles.css
+++ b/chrome-extension/styles.css
@@ -1,0 +1,28 @@
+:root { color-scheme: light dark; font: 14px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; --bg:#fff; --fg:#252323; --muted:#716966; --line:#e9e5e3; --soft:#f7f5f4; --accent:#ce352b; --danger:#a92c23; }
+* { box-sizing:border-box; } [hidden] { display:none!important; }
+body { margin:0; width:392px; max-height:600px; padding:16px; background:var(--bg); color:var(--fg); }
+header { display:flex; justify-content:space-between; align-items:center; margin-bottom:16px; } header strong { font-size:20px; letter-spacing:-.5px; }
+a { color:var(--accent); text-decoration:none; cursor:pointer; } button,input,select,textarea { font:inherit; }
+button { border:1px solid var(--line); border-radius:8px; background:var(--bg); color:var(--fg); padding:7px 11px; cursor:pointer; }
+button:hover { background:var(--soft); } button:disabled { opacity:.6; cursor:wait; }
+button.primary { background:var(--accent); color:#fff; border-color:var(--accent); } button.primary:hover { filter:brightness(.94); }
+:focus-visible { outline:2px solid var(--accent); outline-offset:2px; }
+input,select,textarea { display:block; width:100%; border:1px solid var(--line); border-radius:7px; padding:8px; background:var(--bg); color:var(--fg); min-width:0; }
+label { display:block; font-size:12px; font-weight:600; margin-bottom:10px; } label input,label textarea,label select { margin-top:4px; font-size:14px; font-weight:400; }
+h1 { font-size:23px; letter-spacing:-.6px; line-height:1.25; margin:24px 0 10px; } h2 { margin:0 0 10px; font-size:16px; }
+p { margin:10px 0; } .muted { color:var(--muted); } .small { font-size:11px; } #error { font-size:12px; padding:10px; background:var(--soft); color:var(--danger); border-left:3px solid var(--danger); overflow-wrap:anywhere; }
+#login .primary { width:100%; } .providers { display:flex; gap:8px; margin-top:10px; } .providers button { flex:1; }
+nav { display:flex; gap:4px; border-bottom:1px solid var(--line); margin-bottom:12px; padding-bottom:10px; } nav button { border:0; padding:7px 10px; color:var(--muted); } nav [aria-selected=true] { background:var(--soft); color:var(--accent); font-weight:650; }
+#quick-add { display:flex; gap:8px; } #quick-add input { flex:1; }
+.toolbar { display:flex; align-items:center; gap:6px; margin:10px 0; } .toolbar>span { flex:1; } .toolbar button { font-size:12px; } #refresh { margin-left:auto; }
+#tab-preview { overflow-wrap:anywhere; padding:8px; background:var(--soft); border-radius:6px; }
+#task-scroll { max-height:300px; overflow:auto; scrollbar-gutter:stable; } ul { list-style:none; padding:0; margin:0; }
+.task { display:flex; align-items:flex-start; gap:8px; padding:10px 2px; border-bottom:1px solid var(--line); }
+.task input { flex:none; width:17px; height:17px; margin:3px 0 0; accent-color:var(--accent); cursor:pointer; }
+.task .task-edit { flex:1; min-width:0; padding:0; text-align:left; background:none; border:0; border-radius:2px; }
+.task-title { display:block; overflow-wrap:anywhere; } .task-meta { display:block; font-size:11px; color:var(--muted); margin-top:3px; }
+.task.completed .task-title { color:var(--muted); text-decoration:line-through; } .overdue { color:var(--danger); }
+#empty { padding:32px 8px; text-align:center; } .schedule-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+footer { display:flex; justify-content:space-between; align-items:center; gap:8px; margin-top:12px; padding-top:12px; border-top:1px solid var(--line); } footer>div { min-width:0; } footer span { display:block; overflow-wrap:anywhere; } #connection { font-size:11px; } footer button { font-size:11px; white-space:nowrap; }
+@media (prefers-color-scheme:dark) { :root { --bg:#211d1c; --fg:#f3edeb; --muted:#bdb1aa; --line:#443c39; --soft:#302a28; --accent:#ef6b60; --danger:#ff9b91; } button.primary { color:#211d1c; } }
+@media (prefers-reduced-motion:reduce) { * { scroll-behavior:auto!important; } }

--- a/chrome-extension/test/build.test.js
+++ b/chrome-extension/test/build.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { configuration, manifestFor } from '../build.mjs';
+const env = { SUPABASE_URL: 'https://api.example.test', WEB_APP_URL: 'https://tasks.example.test', SUPABASE_ANON_KEY: 'sb_publishable_testkey' };
+test('build uses exact backend origin, MV3, self-only code and minimal permissions', () => {
+  const config = configuration(env), m = manifestFor(config);
+  assert.equal(m.manifest_version, 3);
+  assert.deepEqual(m.permissions.sort(), ['activeTab', 'identity', 'storage']);
+  assert.deepEqual(m.host_permissions, ['https://api.example.test/*']);
+  assert.match(m.content_security_policy.extension_pages, /script-src 'self'/);
+  assert.match(m.content_security_policy.extension_pages, /wss:\/\/api.example.test/);
+  assert.doesNotMatch(JSON.stringify(m), /<all_urls>|unsafe-eval|unsafe-inline|content_scripts|externally_connectable/);
+});
+test('insecure non-loopback servers, URL credentials, paths and missing configuration are rejected', () => {
+  for (const url of ['http://api.example.test', 'https://u:p@api.example.test', 'https://api.example.test/path', 'https://api.example.test/?secret=x']) {
+    assert.throws(() => configuration({ ...env, SUPABASE_URL: url }));
+  }
+  assert.throws(() => configuration({}));
+  assert.equal(configuration({ ...env, SUPABASE_URL: 'http://localhost:55421' }).apiUrl, 'http://localhost:55421');
+});
+test('service role and secret keys never enter a public build', () => {
+  const jwt = role => 'e30.' + Buffer.from(JSON.stringify({ role })).toString('base64url') + '.signature';
+  for (const key of ['sb_secret_private', jwt('service_role'), 'not-a-public-key']) {
+    assert.throws(() => configuration({ ...env, SUPABASE_ANON_KEY: key }));
+  }
+  assert.equal(configuration({ ...env, SUPABASE_ANON_KEY: jwt('anon') }).anonKey, jwt('anon'));
+});
+test('captcha configuration follows the same public site key as the main web app', () => {
+  assert.equal(configuration(env).captchaEnabled, false);
+  assert.equal(configuration({ ...env, TURNSTILE_SITE_KEY: 'public-site-key' }).captchaEnabled, true);
+});

--- a/chrome-extension/test/core.test.js
+++ b/chrome-extension/test/core.test.js
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { tasksFor, schedule, scheduleFields, taskOperations, tabDraft, callbackValue, recordsOf } from '../src/core.js';
+
+const now = new Date(2026, 8, 7, 12).getTime();
+const task = (id, dueJson = null, extra = {}) => ({ id, userId: 'local-user', content: id,
+  projectId: 'inbox', status: 'open', dueJson, createdAt: now, updatedAt: now, orderKey: id, ...extra });
+const day = date => JSON.stringify({ type: 'allDay', date });
+const records = rows => Object.fromEntries(rows.map(t => [`task:${t.id}`, t]));
+let seq = 0;
+const uuid = () => `id-${++seq}`;
+
+test('Today includes overdue all-day tasks without shifting calendar dates', () => {
+  const r = records([task('old', day('2026-09-06')), task('today', day('2026-09-07')),
+    task('future', day('2026-09-08')), task('none')]);
+  assert.deepEqual(tasksFor(r, 'today', now).map(t => t.id), ['old', 'today']);
+  assert.deepEqual(tasksFor(r, 'upcoming', now).map(t => t.id), ['future']);
+});
+test('completed/deleted tasks and archived projects are excluded', () => {
+  const r = records([task('a', null, { status: 'completed' }), task('b', null, { isDeleted: true }),
+    task('c', day('2026-09-07'), { projectId: 'archived' }), task('d')]);
+  r['project:archived'] = { id: 'archived', isArchived: true };
+  assert.deepEqual(tasksFor(r, 'inbox', now).map(t => t.id), ['d']);
+  assert.deepEqual(tasksFor(r, 'completed', now).map(t => t.id), ['a']);
+});
+test('timed schedules are filtered by local start day', () => {
+  const start = new Date(2026, 8, 7, 23, 30);
+  const due = JSON.stringify({ type: 'timed', start: start.toISOString(), end: new Date(+start + 3600000).toISOString() });
+  assert.equal(tasksFor(records([task('timed', due)]), 'today', now).length, 1);
+});
+test('date-only reschedule preserves local time, duration, timezone and recurrence', () => {
+  const old = { type: 'timed', start: new Date(2026, 8, 7, 9, 15).toISOString(),
+    end: new Date(2026, 8, 7, 10, 45).toISOString(), timeZone: 'Europe/Amsterdam',
+    recurrence: { unit: 'week', interval: 1, seriesId: 'series' } };
+  const next = schedule('2026-09-09', undefined, undefined, JSON.stringify(old));
+  const s = JSON.parse(next);
+  assert.equal(new Date(s.start).getDate(), 9);
+  assert.equal(new Date(s.start).getHours(), 9);
+  assert.equal(new Date(s.start).getMinutes(), 15);
+  assert.equal(Date.parse(s.end) - Date.parse(s.start), 90 * 60000);
+  assert.deepEqual(s.recurrence, old.recurrence);
+  assert.equal(s.timeZone, old.timeZone);
+});
+test('all-day, unschedule and invalid dates are explicit', () => {
+  assert.deepEqual(JSON.parse(schedule('2026-09-08', '', 30, null)), { type: 'allDay', date: '2026-09-08' });
+  assert.equal(schedule('', '', 30, null), null);
+  assert.throws(() => schedule('2026-02-30', '', 30, null));
+  assert.throws(() => schedule('2026-09-08', '24:00', 30, null));
+  assert.throws(() => schedule('2026-09-08', '09:00', 0, null));
+});
+test('schedule editor round-trips the existing timed schedule', () => {
+  const due = schedule('2026-09-08', '09:20', 75, null);
+  const f = scheduleFields(due);
+  assert.equal(f.date, '2026-09-08'); assert.equal(f.time, '09:20'); assert.equal(f.minutes, 75);
+});
+test('rename emits only changed fields, not stale scheduling/project/status data', () => {
+  const r = records([task('a', day('2026-09-07'))]);
+  const [op] = taskOperations(r, { kind: 'edit', id: 'a', patch: { content: ' Renamed ' } }, now, uuid);
+  assert.deepEqual(op.payload, { schemaVersion: 1, commandType: 'task.update', id: 'a', content: 'Renamed', updatedAt: now });
+  assert.equal(op.clientUpdatedAt, new Date(now).toISOString());
+  assert.throws(() => taskOperations(r, { kind: 'edit', id: 'a', patch: { userId: 'other' } }, now, uuid));
+});
+test('create and schedule use the same schema as the Flutter sync client', () => {
+  const ops = taskOperations({}, { kind: 'create', content: 'Test', dueJson: day('2026-09-09') }, now, uuid);
+  const op = ops.find(o => o.entityType === 'task');
+  assert.equal(op.payload.projectId, 'inbox'); assert.equal(op.payload.status, 'open');
+  assert.equal(op.payload.priority, 4); assert.equal(op.payload.dueJson, day('2026-09-09'));
+  assert.ok(ops.some(o => o.entityType === 'task_kanban_status'));
+});
+test('completion includes descendants, history and Done assignment without erasing due', () => {
+  const r = records([task('root'), task('child', null, { parentId: 'root' }),
+    task('already', null, { parentId: 'root', status: 'completed' }), task('other')]);
+  const ops = taskOperations(r, { kind: 'complete', id: 'root' }, now, uuid);
+  assert.deepEqual(ops.filter(o => o.entityType === 'task').map(o => o.entityId), ['root', 'child']);
+  assert.equal(ops.filter(o => o.entityType === 'task_completion').length, 2);
+  assert.equal(ops.filter(o => o.entityType === 'task_kanban_status').length, 2);
+  assert.ok(ops.filter(o => o.entityType === 'task').every(o => !Object.hasOwn(o.payload, 'dueJson')));
+});
+test('restoring completion recovers previous workflow status from completion snapshot', () => {
+  const r = records([task('a', null, { status: 'completed' })]);
+  r['label:work'] = { id: 'work', kind: 'kanbanStatus', systemKey: 'inProgress' };
+  r['task_completion:c'] = { id: 'c', taskId: 'a', completedAt: now,
+    snapshotJson: JSON.stringify({ version: 1, kanban: { previousStatusLabelId: 'work' } }) };
+  const ops = taskOperations(r, { kind: 'uncomplete', id: 'a' }, now, uuid);
+  assert.equal(ops.find(o => o.entityType === 'task_kanban_status').payload.labelId, 'work');
+  assert.equal(ops.find(o => o.entityType === 'task').payload.completedAt, null);
+});
+test('unknown/deleted task cannot be resurrected by edit or completion', () => {
+  assert.throws(() => taskOperations({}, { kind: 'edit', id: 'missing', patch: { content: 'x' } }, now, uuid));
+  assert.throws(() => taskOperations(records([task('a', null, { isDeleted: true })]), { kind: 'complete', id: 'a' }, now, uuid));
+});
+test('tab import rejects privileged URLs and credentials; title remains plain text', () => {
+  assert.deepEqual(tabDraft({ title: '<img src=x>', url: 'https://example.com/a' }), { content: '<img src=x>', description: 'https://example.com/a' });
+  for (const url of ['chrome://settings', 'file:///etc/passwd', 'javascript:alert(1)', 'https://u:p@example.com/']) {
+    assert.throws(() => tabDraft({ title: 'x', url }));
+  }
+});
+test('identity callbacks validate exact origin/path/state and reject duplicates', () => {
+  const base = 'https://' + 'a'.repeat(32) + '.chromiumapp.org/auth-callback';
+  assert.equal(callbackValue(`${base}?state=nonce&code=abc`, base, 'nonce', 'code'), 'abc');
+  for (const url of [`${base}?state=wrong&code=abc`, `${base}?state=nonce&code=a&code=b`,
+    `${base}/evil?state=nonce&code=abc`, `https://evil.test/auth-callback?state=nonce&code=abc`, `${base}?state=nonce&code=abc#access_token=bad`]) {
+    assert.throws(() => callbackValue(url, base, 'nonce', 'code'));
+  }
+});
+test('recordsOf excludes tombstones', () => {
+  assert.equal(recordsOf(records([task('a'), task('b', null, { isDeleted: true })]), 'task').length, 1);
+});
+test('removing a repeating schedule requires the full app instead of silently dropping the rule', () => {
+  assert.throws(() => schedule('', '', 30, JSON.stringify({ type: 'allDay', date: '2026-09-07', recurrence: { unit: 'day' } })), /repeating/i);
+});
+test('an oversized page URL is rejected, not truncated into another link', () => {
+  assert.throws(() => tabDraft({ title: 'Page', url: 'https://example.test/?q=' + 'a'.repeat(8200) }), /long/i);
+});

--- a/chrome-extension/test/popup.test.js
+++ b/chrome-extension/test/popup.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import vm from 'node:vm';
+import * as core from '../src/core.js';
+
+test('Add current tab saves immediately without consuming a typed task draft', async () => {
+  const elements = new Map(), messages = [];
+  const element = () => ({ value: '', dataset: {}, listeners: {}, classList: { add() {} },
+    addEventListener(type, listener) { this.listeners[type] = listener; },
+    setAttribute() {}, append() {}, replaceChildren() {}, querySelectorAll: () => [] });
+  const get = id => { if (!elements.has(id)) elements.set(id, element()); return elements.get(id); };
+  const views = ['today', 'inbox'].map(view => Object.assign(element(), { id: `tab-${view}`, dataset: { view } }));
+  const snapshot = { user: { id: 'user-a', email: 'a@example.test' }, records: {}, pending: 0, error: '' };
+  let currentTab = { title: 'A useful page', url: 'https://example.test/article' };
+  // Run the actual popup handlers; replace only browser APIs and module imports.
+  const source = (await readFile(new URL('../src/popup.js', import.meta.url), 'utf8')).replace(/^import .*;\n/gm, '');
+  await vm.runInNewContext(`(async () => {${source}\n})()`, {
+    ...core, config: { webUrl: 'https://app.example.test' },
+    Realtime: class { start() {} stop() {} },
+    document: { hidden: true, activeElement: element(), getElementById: get, createElement: element,
+      createDocumentFragment: element, addEventListener() {},
+      querySelectorAll: selector => selector === '[data-view]' ? views : [...elements.values()] },
+    window: { addEventListener() {} }, setInterval() {}, clearInterval() {}, clearTimeout() {},
+    chrome: { tabs: { query: async () => [currentTab] }, runtime: { onMessage: { addListener() {} },
+      sendMessage: async message => { messages.push(structuredClone(message)); return { ok: true, value: snapshot }; } } },
+  });
+  get('new-title').value = 'My unfinished task';
+  await get('save-tab').listeners.click();
+  const saved = messages.filter(message => message.type === 'mutate');
+  assert.equal(saved.length, 1);
+  assert.deepEqual(saved[0].payload, { owner: 'user-a', action: { kind: 'create',
+    content: 'A useful page', description: 'https://example.test/article', dueJson: core.schedule(core.dateKey(), '', 30, null) } });
+  assert.equal(get('new-title').value, 'My unfinished task');
+  views[1].listeners.click();
+  await get('save-tab').listeners.click();
+  assert.equal(messages.filter(message => message.type === 'mutate')[1].payload.action.dueJson, null);
+  currentTab = { title: 'Settings', url: 'chrome://settings' };
+  await get('save-tab').listeners.click();
+  assert.equal(messages.filter(message => message.type === 'mutate').length, 2);
+  assert.match(get('error').textContent, /HTTP/);
+});

--- a/chrome-extension/test/realtime.test.js
+++ b/chrome-extension/test/realtime.test.js
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Realtime } from '../src/realtime.js';
+import { pkce } from '../src/client.js';
+import { parseChallenge } from '../../web/auth/extension-challenge.js';
+const tick = () => new Promise(resolve => setImmediate(resolve));
+class Socket {
+  static instances = [];
+  constructor(url) { this.url = url; this.readyState = 1; this.sent = []; Socket.instances.push(this); }
+  send(text) { this.sent.push(JSON.parse(text)); }
+  close() { this.readyState = 3; }
+  message(value) { this.onmessage?.({ data: JSON.stringify(value) }); }
+}
+const context = { apiUrl: 'https://api.example.test', anonKey: 'public', accessToken: 'private-token', userId: 'a', deviceId: 'device' };
+test('Realtime joins the same private account channel, pulls on join/hints and stops on close', async () => {
+  let pulls = 0, live = false;
+  const rt = new Realtime(async () => context, () => pulls++, value => { live = value; }, Socket);
+  rt.start(); await tick(); const socket = Socket.instances.at(-1); socket.onopen();
+  const join = socket.sent[0];
+  assert.equal(join.topic, 'realtime:sync:a:pomodoist'); assert.equal(join.payload.config.private, true);
+  assert.equal(join.payload.access_token, 'private-token'); assert.ok(!socket.url.includes('private-token'));
+  socket.message({ topic: join.topic, event: 'phx_reply', ref: join.ref, payload: { status: 'ok' } });
+  assert.equal(live, true); assert.equal(pulls, 1);
+  socket.message({ topic: join.topic, event: 'broadcast', payload: { event: 'changed', payload: { appId: 'pomodoist', deviceId: 'other' } } });
+  assert.equal(pulls, 2);
+  socket.message({ topic: join.topic, event: 'broadcast', payload: { event: 'changed', payload: { appId: 'pomodoist', deviceId: 'device' } } });
+  assert.equal(pulls, 2); rt.stop(); assert.equal(socket.readyState, 3); assert.equal(live, false);
+});
+test('join failures are not displayed as live and schedule a bounded reconnect', async () => {
+  let live = false;
+  const rt = new Realtime(async () => context, () => {}, value => { live = value; }, Socket);
+  rt.start(); await tick(); const socket = Socket.instances.at(-1); socket.onopen(); const join = socket.sent[0];
+  socket.message({ topic: join.topic, event: 'phx_reply', ref: join.ref, payload: { status: 'error' } });
+  assert.equal(live, false); assert.equal(socket.readyState, 3); assert.ok(rt.retry); rt.stop();
+});
+test('closing during async token retrieval cannot open an orphan socket', async () => {
+  let resolve; const promise = new Promise(r => { resolve = r; });
+  const count = Socket.instances.length;
+  const rt = new Realtime(() => promise, () => {}, () => {}, Socket); rt.start(); rt.stop(); resolve(context); await tick();
+  assert.equal(Socket.instances.length, count);
+});
+test('PKCE is random and uses the SHA-256 challenge, never a reusable secret', async () => {
+  const a = await pkce(), b = await pkce();
+  assert.notEqual(a.verifier, b.verifier); assert.equal(a.verifier.length, 43);
+  assert.equal(a.challenge, Buffer.from(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(a.verifier))).toString('base64url'));
+});
+test('hosted CAPTCHA accepts only a nonce-bound exact Chrome identity callback', () => {
+  const callback = 'https://' + 'a'.repeat(32) + '.chromiumapp.org/captcha-callback';
+  const href = 'https://tasks.example.test/auth/extension-challenge.html?returnTo=' + encodeURIComponent(callback) + '#state=' + 'n'.repeat(43);
+  assert.equal(parseChallenge(href).target.href, callback);
+  for (const target of ['https://evil.test/captcha-callback', callback.replace('chromiumapp.org', 'chromiumapp.org.evil.test'),
+    callback + '?x=1', callback.replace('https:', 'http:'), callback.replace('/captcha-callback', '/elsewhere')]) {
+    assert.throws(() => parseChallenge('https://tasks.example.test/?returnTo=' + encodeURIComponent(target) + '#state=' + 'n'.repeat(43)));
+  }
+  assert.throws(() => parseChallenge(href + '&state=duplicate'));
+});

--- a/chrome-extension/test/sync.test.js
+++ b/chrome-extension/test/sync.test.js
@@ -1,0 +1,143 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { Store, synchronize } from '../src/sync.js';
+import { Client } from '../src/client.js';
+
+const session = (id = 'user-a') => ({ user: { id, email: `${id}@example.test` }, access_token: 'access', refresh_token: 'refresh', expires_at: Date.now() / 1000 + 3600 });
+function storage() {
+  let data = {};
+  return { async get(key) { return { [key]: structuredClone(data[key]) }; },
+    async set(value) { data = structuredClone({ ...data, ...value }); } };
+}
+async function setup() {
+  const disk = storage(), store = new Store(disk, 'https://api.example.test');
+  await store.init(); await store.acceptSession(session()); return { disk, store };
+}
+const pull = (changes = [], nextCursor = 0, hasMore = false) => ({ changes, nextCursor, hasMore });
+const change = (id, serverRevision, extra = {}) => ({ entityType: 'task', entityId: id, serverRevision,
+  data: { id, content: id, projectId: 'inbox', status: 'open', ...extra } });
+const api = handler => ({ rpc: handler, broadcast: async () => {}, overview: async () => ({ profile: { pomodoistIsPro: true } }) });
+
+test('outbox is durable before network and stable across worker restarts', async () => {
+  const { disk, store } = await setup();
+  await store.enqueue({ kind: 'create', content: 'Offline task' }, 'user-a');
+  const ids = store.data.outbox.map(o => o.opId);
+  await assert.rejects(synchronize(store, api(async () => { throw new Error('Offline'); })));
+  const restarted = new Store(disk, 'https://api.example.test'); await restarted.init();
+  assert.deepEqual(restarted.data.outbox.map(o => o.opId), ids);
+  assert.equal(Object.values(restarted.snapshot().records).filter(r => r.content === 'Offline task').length, 1);
+});
+test('push ack never advances pull cursor past concurrent remote changes', async () => {
+  const { store } = await setup(); await store.enqueue({ kind: 'create', content: 'Local' }, 'user-a');
+  let since;
+  await synchronize(store, api(async (name, body) => {
+    if (name === 'push_changes') return { serverRevision: 100, applied: [] };
+    since = body.p_since_revision; return pull([change('remote', 10)], 100);
+  }));
+  assert.equal(since, 0); assert.equal(store.data.cursor, 100); assert.equal(store.data.records['task:remote'].content, 'remote');
+  assert.equal(store.data.outbox.length, 0);
+});
+test('pagination persists records and cursor together and resumes after a failed page', async () => {
+  const { disk, store } = await setup();
+  await assert.rejects(synchronize(store, api(async (_, body) => {
+    if (body.p_since_revision === 0) return pull([change('first', 1)], 1, true);
+    throw new Error('Second page failed');
+  })));
+  const resumed = new Store(disk, 'https://api.example.test'); await resumed.init();
+  assert.equal(resumed.data.cursor, 1); assert.ok(resumed.data.records['task:first']);
+  await synchronize(resumed, api(async (_, body) => {
+    assert.equal(body.p_since_revision, 1); return pull([change('second', 2)], 2);
+  }));
+  assert.ok(resumed.data.records['task:second']);
+});
+test('server cursor reset rebuilds cache rather than resurrecting removed tasks', async () => {
+  const { store } = await setup();
+  await store.save({ cursor: 10, records: { 'task:old': { id: 'old' } } });
+  let calls = 0;
+  await synchronize(store, api(async (_, body) => {
+    if (++calls === 1) { assert.equal(body.p_since_revision, 10); return pull([], 0); }
+    assert.equal(body.p_since_revision, 0); return pull([change('new', 1)], 1);
+  }));
+  assert.equal(store.data.records['task:old'], undefined); assert.ok(store.data.records['task:new']);
+});
+test('tombstones remove tasks from visible cache, and pagination cannot spin', async () => {
+  const { store } = await setup();
+  await synchronize(store, api(async () => pull([{ ...change('gone', 1), deletedAt: new Date().toISOString() }], 1)));
+  assert.equal(store.snapshot().records['task:gone'].isDeleted, true);
+  await assert.rejects(synchronize(store, api(async () => pull([], 1, true))), /cursor/i);
+});
+test('logout/account switch clear credentials, cache and pending writes without cross-account replay', async () => {
+  const { store } = await setup(); await store.enqueue({ kind: 'create', content: 'Private' }, 'user-a');
+  await assert.rejects(store.acceptSession(session('user-b')), /unsynced/i);
+  await assert.rejects(store.logout(false), /unsynced/i);
+  await store.logout(true); await store.acceptSession(session('user-b'));
+  assert.deepEqual(store.data.records, {}); assert.equal(store.data.outbox.length, 0);
+  await assert.rejects(store.enqueue({ kind: 'create', content: 'Old view' }, 'user-a'), /account/i);
+});
+test('failed persistence does not mutate in-memory state or pretend a task was saved', async () => {
+  const { store } = await setup(); const before = structuredClone(store.data);
+  store.storage.set = async () => { throw new Error('Storage full'); };
+  await assert.rejects(store.enqueue({ kind: 'create', content: 'Lost' }, 'user-a'));
+  assert.deepEqual(store.data, before);
+});
+test('malformed push ack leaves pending operations intact', async () => {
+  const { store } = await setup(); await store.enqueue({ kind: 'create', content: 'Keep' }, 'user-a');
+  await assert.rejects(synchronize(store, api(async () => ({}))), /response/i);
+  assert.equal(store.data.outbox.length, 2);
+});
+test('backend changes cannot reuse an old instance session or cache', async () => {
+  const { disk, store } = await setup(); await store.enqueue({ kind: 'create', content: 'Private' }, 'user-a');
+  const different = new Store(disk, 'https://other.example.test'); await different.init();
+  assert.equal(different.data.session, null); assert.deepEqual(different.data.records, {});
+});
+const response = (body, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+const config = { apiUrl: 'https://api.example.test', anonKey: 'sb_publishable_test' };
+test('simultaneous requests rotate the refresh token once and persist it before continuing', async () => {
+  const { store } = await setup(); await store.save({ session: { ...session(), expires_at: 1 } });
+  let refreshes = 0;
+  const client = new Client(config, store, async (url, options) => {
+    assert.equal(options.redirect, 'error'); assert.equal(options.credentials, 'omit');
+    if (url.includes('grant_type=refresh_token')) { refreshes++; return response({ ...session(), refresh_token: 'rotated' }); }
+    assert.equal(store.data.session.refresh_token, 'rotated'); return response({ profile: {} });
+  });
+  await Promise.all([client.overview(), client.overview()]); assert.equal(refreshes, 1);
+});
+test('401 retries once with a refreshed token, not an unbounded loop', async () => {
+  const { store } = await setup(); let rpcs = 0, refreshes = 0;
+  const client = new Client(config, store, async url => {
+    if (url.includes('refresh_token')) { refreshes++; return response(session()); }
+    rpcs++; return response({}, 401);
+  });
+  await assert.rejects(client.overview()); assert.equal(rpcs, 2); assert.equal(refreshes, 1);
+});
+test('expired session hides cached tasks but preserves same-owner unsynced changes for reauthentication', async () => {
+  const { store } = await setup(); await store.enqueue({ kind: 'create', content: 'Private' }, 'user-a');
+  await store.save({ session: { ...session(), expires_at: 1 } });
+  const client = new Client(config, store, async () => response({ error: 'invalid_grant' }, 400));
+  await assert.rejects(client.overview()); assert.equal(store.snapshot().user, null);
+  assert.deepEqual(store.snapshot().records, {});
+  await store.acceptSession(session()); assert.equal(store.data.outbox.length, 2);
+});
+test('auth errors never echo the raw server body or credentials', async () => {
+  const { store } = await setup();
+  const client = new Client(config, store, async () => response({ error_description: 'PASSWORD_SECRET' }, 400));
+  await assert.rejects(client.password('a@example.test', 'PASSWORD_SECRET'), err => !err.message.includes('PASSWORD_SECRET'));
+});
+test('a committed push whose response was lost is retried with the same operation IDs', async () => {
+  const { store } = await setup(); await store.enqueue({ kind: 'create', content: 'Exactly once' }, 'user-a');
+  let first = true, original; const received = new Set(), applied = [];
+  const client = api(async (name, body) => {
+    if (name === 'pull_changes') return pull(applied, 2);
+    const ids = body.p_operations.map(op => op.opId);
+    if (!original) original = ids; else assert.deepEqual(ids, original);
+    for (const op of body.p_operations) if (!received.has(op.opId)) {
+      received.add(op.opId); applied.push({ entityType: op.entityType, entityId: op.entityId, data: op.payload });
+    }
+    if (first) { first = false; throw new Error('Response lost after commit'); }
+    return { serverRevision: 2, applied };
+  });
+  await assert.rejects(synchronize(store, client));
+  await synchronize(store, client);
+  assert.equal(received.size, 2); assert.equal(store.data.outbox.length, 0);
+  assert.equal(Object.keys(store.data.records).filter(key => key.startsWith('task:')).length, 1);
+});

--- a/chrome-extension/test/sync.test.js
+++ b/chrome-extension/test/sync.test.js
@@ -92,6 +92,14 @@ test('backend changes cannot reuse an old instance session or cache', async () =
 });
 const response = (body, status = 200) => new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
 const config = { apiUrl: 'https://api.example.test', anonKey: 'sb_publishable_test' };
+test('default browser fetch keeps its global receiver for account requests', async t => {
+  const { store } = await setup();
+  t.mock.method(globalThis, 'fetch', async function () {
+    if (this !== globalThis) throw new TypeError('Illegal invocation');
+    return response({ profile: { pomodoistIsPro: true } });
+  });
+  assert.deepEqual(await new Client(config, store).overview(), { profile: { pomodoistIsPro: true } });
+});
 test('simultaneous requests rotate the refresh token once and persist it before continuing', async () => {
   const { store } = await setup(); await store.save({ session: { ...session(), expires_at: 1 } });
   let refreshes = 0;
@@ -109,6 +117,29 @@ test('401 retries once with a refreshed token, not an unbounded loop', async () 
     rpcs++; return response({}, 401);
   });
   await assert.rejects(client.overview()); assert.equal(rpcs, 2); assert.equal(refreshes, 1);
+});
+test('a rejected realtime hint cannot sign out a successfully synchronized account', async () => {
+  const { store } = await setup();
+  await store.save({ overviewAt: Date.now() });
+  await store.enqueue({ kind: 'create', content: 'Saved task' }, 'user-a');
+  let applied = [], refreshes = 0;
+  const client = new Client(config, store, async (url, options) => {
+    if (url.endsWith('/push_changes')) {
+      applied = JSON.parse(options.body).p_operations.map(op => ({
+        entityType: op.entityType, entityId: op.entityId, data: op.payload,
+      }));
+      return response({ applied, serverRevision: 1 });
+    }
+    if (url.endsWith('/pull_changes')) return response(pull(applied, 1));
+    if (url.includes('grant_type=refresh_token')) { refreshes++; return response(session()); }
+    if (url.endsWith('/realtime/v1/api/broadcast')) return response({ message: 'Unauthorized' }, 401);
+    throw new Error(`Unexpected request: ${url}`);
+  });
+  await synchronize(store, client);
+  assert.equal(store.snapshot().user?.id, 'user-a');
+  assert.equal(store.snapshot().pending, 0);
+  assert.ok(Object.values(store.snapshot().records).some(row => row.content === 'Saved task'));
+  assert.equal(refreshes, 0);
 });
 test('expired session hides cached tasks but preserves same-owner unsynced changes for reauthentication', async () => {
   const { store } = await setup(); await store.enqueue({ kind: 'create', content: 'Private' }, 'user-a');

--- a/web/auth/extension-challenge.html
+++ b/web/auth/extension-challenge.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="referrer" content="no-referrer"><title>Pomodoist verification</title>
+<style>body{font:16px/1.5 system-ui,sans-serif;max-width:420px;margin:12vh auto;padding:24px}button{font:inherit;padding:8px 16px}#widget{margin:20px 0}[hidden]{display:none!important}</style>
+<script src="/config.js"></script><script type="module" src="./extension-challenge.js"></script></head>
+<body><h1>Pomodoist security check</h1><p id="status" role="status">Validating verification request…</p>
+<div id="widget"></div><button id="retry" type="button" hidden>Retry</button>
+<noscript>JavaScript is required to complete verification.</noscript></body></html>

--- a/web/auth/extension-challenge.js
+++ b/web/auth/extension-challenge.js
@@ -1,0 +1,46 @@
+// Hosted on the web app, not packaged in the extension. No password or account
+// token crosses this page; only a short-lived CAPTCHA token and a random nonce.
+export function parseChallenge(href) {
+  const request = new URL(href), query = request.searchParams, fragment = new URLSearchParams(request.hash.slice(1));
+  const state = fragment.get('state'), raw = query.get('returnTo');
+  if ([...query.keys()].length !== 1 || query.getAll('returnTo').length !== 1 ||
+      [...fragment.keys()].length !== 1 || fragment.getAll('state').length !== 1 ||
+      !/^[A-Za-z0-9_-]{32,128}$/.test(state ?? '')) throw new Error('Invalid verification request.');
+  const target = new URL(raw);
+  if (target.href !== raw || target.protocol !== 'https:' || !/^[a-p]{32}\.chromiumapp\.org$/.test(target.hostname) ||
+      target.pathname !== '/captcha-callback' || target.port || target.username || target.password || target.search || target.hash) {
+    throw new Error('Invalid extension callback.');
+  }
+  return { target, state };
+}
+if (typeof document !== 'undefined') {
+  const status = document.getElementById('status'), retry = document.getElementById('retry');
+  let request, widgetId, completed = false;
+  const failed = message => { status.textContent = message; retry.hidden = false; };
+  const render = () => {
+    retry.hidden = true;
+    if (widgetId !== undefined) window.turnstile.remove(widgetId);
+    status.textContent = 'Confirm you are human to continue signing in.';
+    widgetId = window.turnstile.render('#widget', {
+      sitekey: window.pomodoistRuntimeConfig.turnstileSiteKey,
+      callback: token => {
+        if (completed || typeof token !== 'string' || !token || token.length > 2048 || /[\u0000-\u001f\u007f-\u009f]/.test(token)) return;
+        completed = true; const callback = new URL(request.target.href);
+        callback.searchParams.set('state', request.state); callback.searchParams.set('token', token);
+        status.textContent = 'Verified. Returning to Pomodoist…'; location.replace(callback.href);
+      },
+      'error-callback': () => failed('Verification failed. Please retry.'),
+      'expired-callback': () => failed('Verification expired. Please retry.'),
+    });
+  };
+  try {
+    request = parseChallenge(location.href);
+    if (!window.pomodoistRuntimeConfig?.turnstileSiteKey) throw new Error('Verification is not configured on this server.');
+    const script = document.createElement('script');
+    script.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+    script.onload = () => { clearTimeout(timeout); try { render(); } catch { failed('Verification could not start. Please retry.'); } };
+    script.onerror = () => { clearTimeout(timeout); failed('Verification could not load. Check your connection and retry.'); };
+    const timeout = setTimeout(() => failed('Verification timed out. Please retry.'), 15000);
+    retry.addEventListener('click', () => location.reload()); document.head.append(script);
+  } catch (error) { status.textContent = `${error.message} Close this window and retry sign-in from the extension.`; }
+}


### PR DESCRIPTION
## Summary

Implements the source-side Chrome extension work for #22.

- adds a lightweight Manifest V3 popup with Today, Upcoming, Inbox and Done views
- supports existing-account email/password auth plus Google/Apple PKCE flows
- creates, edits, schedules, completes and restores tasks using the existing schema-v1 sync contract
- adds explicit current-tab title/URL capture with `activeTab`
- uses durable local outbox/cursor state, idempotent retry behavior and private Realtime sync hints
- reads the existing account overview so subscription/entitlement status stays server-owned across platforms
- limits permissions to `storage`, `identity`, `activeTab` and the configured backend origin
- adds a hosted CAPTCHA handoff, privacy notes, build instructions and a Chrome-extension CI/package job

The Chrome Web Store publication step is intentionally not claimed as complete here: it still requires the production extension ID/OAuth allowlist, production backend values, store privacy/data-use declarations, publisher credentials and an actual store upload/review. Issue #22 should remain open until that operational release is completed.

## Checks

- [x] `npm test` — 39/39 tests pass locally
- [x] validation build succeeds with public test configuration
- [x] Relevant tests pass.
- [x] I have read and agree to the [Contributor License Agreement](../CLA.md)
      for this contribution.

### Verification note

The available local Chromium is managed by policy and blocks loading unpacked extensions, so I did not claim an end-to-end packaged browser smoke test. The added tests cover task/domain behavior, synchronization durability/retries, auth refresh/PKCE/CAPTCHA validation, Realtime protocol handling, Manifest V3 permissions/CSP, and build-time secret rejection.