### PR TITLE
feat(android): add production-ready build and release pipeline (#50)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,109 @@
+name: Android production release
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: 'Optional versionCode override; must exceed previous Play uploads'
+        type: string
+        required: false
+  push:
+    tags: ['v*.*.*']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  signed-apk-and-bundle:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    environment: android-production
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Require a reviewed main commit and valid version
+        env:
+          INPUT_BUILD_NUMBER: ${{ inputs.build_number }}
+        run: |
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main || {
+            echo 'Production Android builds must come from a commit already in main.' >&2
+            exit 1
+          }
+          if [[ "$GITHUB_REF_TYPE" == tag ]]; then
+            [[ "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]] || exit 1
+            echo "ANDROID_BUILD_NAME=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+          fi
+          if [[ -n "$INPUT_BUILD_NUMBER" ]]; then
+            [[ "$INPUT_BUILD_NUMBER" =~ ^[1-9][0-9]{0,9}$ ]] || exit 1
+            echo "ANDROID_BUILD_NUMBER=$INPUT_BUILD_NUMBER" >> "$GITHUB_ENV"
+          fi
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version-file: .fvmrc
+      - name: Test Android release tooling
+        run: python3 -m unittest discover -s tool/android -p 'test_*.py' -v
+      - name: Generate public production configuration
+        env:
+          TURNSTILE_SITE_KEY: ${{ vars.TURNSTILE_SITE_KEY }}
+          SENTRY_DSN: ${{ vars.SENTRY_DSN }}
+        run: |
+          umask 077
+          python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          config = {
+              'POMODOIST_ENVIRONMENT': 'production',
+              'WEB_APP_URL': 'https://app.pomodoist.com',
+              'POMODOIST_REGISTRATION_URL': 'https://app.pomodoist.com/auth/challenge',
+              'TURNSTILE_SITE_KEY': os.environ['TURNSTILE_SITE_KEY'],
+              'SENTRY_DSN': os.environ.get('SENTRY_DSN', ''),
+              'POMODOIST_BILLING_CHANNEL': 'storekit',
+          }
+          path = Path(os.environ['RUNNER_TEMP']) / 'android-production.json'
+          path.write_text(json.dumps(config))
+          PY
+          python3 tool/android/validate_config.py "$RUNNER_TEMP/android-production.json"
+      - name: Decode upload key
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          umask 077
+          test -n "$ANDROID_KEYSTORE_BASE64" || { echo 'ANDROID_KEYSTORE_BASE64 is required.' >&2; exit 1; }
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$RUNNER_TEMP/android-release.jks"
+      - name: Build and verify production APK and AAB
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/android-release.jks
+          ANDROID_STORE_PASSWORD: ${{ secrets.ANDROID_STORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_SIGNING_CERT_SHA256: ${{ secrets.ANDROID_SIGNING_CERT_SHA256 }}
+          POMODOIST_RELEASE: ${{ github.sha }}
+        run: |
+          test -n "$ANDROID_SIGNING_CERT_SHA256" || { echo 'ANDROID_SIGNING_CERT_SHA256 is required.' >&2; exit 1; }
+          bash tool/android/build_release.sh "$RUNNER_TEMP/android-production.json"
+      - name: Save signed release artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pomodoist-android-${{ github.sha }}
+          path: build/android/release/
+          if-no-files-found: error
+          retention-days: 30
+      - name: Save Dart symbols for crash symbolication
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pomodoist-android-symbols-${{ github.sha }}
+          path: build/android/symbols/
+          if-no-files-found: error
+          retention-days: 90
+      - name: Remove signing material and configuration
+        if: always()
+        run: rm -f "$RUNNER_TEMP/android-release.jks" "$RUNNER_TEMP/android-production.json"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,93 @@
+name: Android validation
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: android-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release-build-smoke:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version-file: .fvmrc
+      - name: Test Android packaging and public configuration
+        run: python3 -m unittest discover -s tool/android -p 'test_*.py' -v
+      - run: flutter pub get --enforce-lockfile
+      - name: Test Android runtime contracts
+        run: flutter test test/android_platform_test.dart
+      - name: Prove release signing fails closed
+        run: |
+          if flutter build apk --release --target-platform android-arm64 \
+              --dart-define=POMODOIST_BILLING_CHANNEL=storekit > "$RUNNER_TEMP/unsigned-build.log" 2>&1; then
+            echo 'Release unexpectedly succeeded without signing credentials.' >&2
+            exit 1
+          fi
+          if ! grep -q 'Android release signing is required' "$RUNNER_TEMP/unsigned-build.log"; then
+            cat "$RUNNER_TEMP/unsigned-build.log"
+            exit 1
+          fi
+      - name: Create disposable validation key (never a production key)
+        run: |
+          umask 077
+          password=$(openssl rand -hex 24)
+          echo "::add-mask::$password"
+          export CI_KEY_PASSWORD="$password"
+          keytool -genkeypair -noprompt -storetype JKS -keyalg RSA -keysize 2048 \
+            -validity 2 -alias ci-validation -dname 'CN=Pomodoist CI Validation' \
+            -keystore "$RUNNER_TEMP/android-validation.jks" \
+            -storepass:env CI_KEY_PASSWORD -keypass:env CI_KEY_PASSWORD
+          {
+            echo "ANDROID_KEYSTORE_PATH=$RUNNER_TEMP/android-validation.jks"
+            echo "ANDROID_STORE_PASSWORD=$password"
+            echo 'ANDROID_KEY_ALIAS=ci-validation'
+            echo "ANDROID_KEY_PASSWORD=$password"
+          } >> "$GITHUB_ENV"
+      - name: Compile release APK and AAB without production account access
+        run: |
+          common=(--release --dart-define=POMODOIST_ENVIRONMENT=local
+            --dart-define=WEB_APP_URL=https://app.pomodoist.com
+            --dart-define=POMODOIST_BILLING_CHANNEL=storekit
+            "--dart-define=POMODOIST_RELEASE=$GITHUB_SHA")
+          flutter build apk "${common[@]}"
+          flutter build appbundle "${common[@]}"
+          bash tool/android/verify_artifacts.sh
+      - name: Enable emulator acceleration
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Install, launch and resume on Android 15
+        uses: ReactiveCircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
+        with:
+          api-level: 35
+          arch: x86_64
+          target: google_apis
+          disable-animations: true
+          script: bash tool/android/smoke_test.sh
+      - name: Save CI-only APK and AAB
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: android-validation-NOT-FOR-DISTRIBUTION
+          path: |
+            build/app/outputs/flutter-apk/app-release.apk
+            build/app/outputs/bundle/release/app-release.aab
+          if-no-files-found: error
+          retention-days: 3
+      - name: Remove disposable signing material
+        if: always()
+        run: rm -f "$RUNNER_TEMP/android-validation.jks" "$RUNNER_TEMP/unsigned-build.log"

--- a/.github/workflows/chrome-extension.yml
+++ b/.github/workflows/chrome-extension.yml
@@ -12,8 +12,8 @@ jobs:
   test-and-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - name: Unit and protocol tests
@@ -32,7 +32,7 @@ jobs:
           npm run build
           cd dist
           zip -r ../pomodoist-chrome-validation.zip .
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: chrome-extension-validation-build
           path: chrome-extension/pomodoist-chrome-validation.zip

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,12 @@ tmp/
 .fvm/
 /GNUmakefile
 tool/apple/VOICE_TESTING.md
+
+# Android signing material (public templates remain tracked).
+/android/key.properties
+*.jks
+*.keystore
+*.p12
+*.pfx
+/android/.kotlin/
+/android/captures/

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,5 @@
+# Android
+
+See [Android builds and release verification](../tool/android/README.md) for
+local development, production signing, APK/AAB builds, GitHub Actions setup,
+permission behavior, billing boundaries and the physical-device release checklist.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,42 +1,114 @@
+import java.security.KeyStore
+import java.security.cert.X509Certificate
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+// Secrets belong in the environment or ignored android/key.properties, never
+// in dart-defines (which are compiled into the distributed application).
+val signingProperties = Properties()
+val signingPropertiesFile = rootProject.file("key.properties")
+if (signingPropertiesFile.isFile) {
+    signingPropertiesFile.inputStream().use { signingProperties.load(it) }
+}
+fun signingValue(environment: String, property: String): String? =
+    System.getenv(environment)?.takeIf { it.isNotBlank() }
+        ?: signingProperties.getProperty(property)?.takeIf { it.isNotBlank() }
+
+val releaseStorePath = signingValue("ANDROID_KEYSTORE_PATH", "storeFile")
+val releaseStorePassword = signingValue("ANDROID_STORE_PASSWORD", "storePassword")
+val releaseKeyAlias = signingValue("ANDROID_KEY_ALIAS", "keyAlias")
+val releaseKeyPassword = signingValue("ANDROID_KEY_PASSWORD", "keyPassword")
+val releaseStoreFile = releaseStorePath?.let { rootProject.file(it) }
+
+fun validateReleaseSigning() {
+    val storeFile = releaseStoreFile
+    val storePassword = releaseStorePassword
+    val keyAlias = releaseKeyAlias
+    val keyPassword = releaseKeyPassword
+    if (storeFile == null || !storeFile.isFile || storePassword == null ||
+        keyAlias == null || keyPassword == null) {
+        throw GradleException(
+            "Android release signing is required. Configure ANDROID_KEYSTORE_PATH, " +
+                "ANDROID_STORE_PASSWORD, ANDROID_KEY_ALIAS and ANDROID_KEY_PASSWORD " +
+                "or android/key.properties. See tool/android/README.md."
+        )
+    }
+    if (keyAlias.equals("androiddebugkey", ignoreCase = true)) {
+        throw GradleException("Android debug keys must not sign release builds.")
+    }
+    try {
+        val store = KeyStore.getInstance(storeFile, storePassword.toCharArray())
+        if (!store.isKeyEntry(keyAlias) ||
+            store.getKey(keyAlias, keyPassword.toCharArray()) == null) {
+            throw GradleException("The release alias must contain a private key.")
+        }
+        val certificate = store.getCertificate(keyAlias) as? X509Certificate
+            ?: throw GradleException("The release alias must have an X.509 certificate.")
+        certificate.checkValidity()
+        if (certificate.subjectX500Principal.name.contains("CN=Android Debug", ignoreCase = true)) {
+            throw GradleException("Android Debug certificates must not sign release builds.")
+        }
+    } catch (error: GradleException) {
+        throw error
+    } catch (_: Exception) {
+        // Do not print passwords, keystore contents, or nested provider errors.
+        throw GradleException("Cannot unlock the Android release key or its certificate is invalid.")
+    }
+}
+
+// Guard the actual task graph, not only a guessed command name: Flutter,
+// assemble, bundle, install and abbreviated Gradle release tasks are covered.
+// Debug builds and IDE synchronization do not need signing credentials.
+gradle.taskGraph.whenReady {
+    if (allTasks.any { it.project == project && it.name.contains("Release", ignoreCase = true) }) {
+        validateReleaseSigning()
+    }
+}
+
 android {
-    namespace = "com.example.pomodoist"
+    namespace = "com.finchforge.pomodoist"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_17.toString()
     }
-
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.pomodoist"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        applicationId = "com.finchforge.pomodoist"
+        minSdk = maxOf(24, flutter.minSdkVersion)
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
     }
-
-    buildTypes {
-        release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+    signingConfigs {
+        create("release") {
+            storeFile = releaseStoreFile
+            storePassword = releaseStorePassword
+            keyAlias = releaseKeyAlias
+            keyPassword = releaseKeyPassword
         }
     }
+    buildTypes {
+        release {
+            signingConfig = signingConfigs.getByName("release")
+            isMinifyEnabled = true
+            isShrinkResources = true
+        }
+    }
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }
 
 flutter {

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,6 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <!-- The INTERNET permission is required for development. Specifically,
-         the Flutter tool needs it to communicate with the running application
-         to allow setting breakpoints, to provide hot reload, etc.
-    -->
-    <uses-permission android:name="android.permission.INTERNET"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Only debug builds may reach HTTP development servers/emulator loopback. -->
+    <application android:usesCleartextTraffic="true" tools:replace="android:usesCleartextTraffic" />
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,10 +1,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- User-granted access; scheduling falls back to inexact alarms if denied. -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
 
     <application
-        android:label="pomodoist"
+        android:label="Pomodoist"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:usesCleartextTraffic="false">
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -14,40 +24,53 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
-            <!-- Specifies an Android theme to apply to this Activity as soon as
-                 the Android process has started. This theme is visible to the user
-                 while the Flutter UI initializes. After that, this theme continues
-                 to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
+            <!-- app_links owns callbacks; Flutter's router must not consume them twice. -->
+            <meta-data android:name="flutter_deeplinking_enabled" android:value="false" />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="pomodoist" android:host="login-callback" />
+                <data android:scheme="pomodoist" android:host="captcha-callback" />
+                <data android:scheme="pomodoist" android:host="google-calendar-connected" />
+                <data android:scheme="pomodoist" android:host="focus" />
+                <data android:scheme="pomodoist" android:host="purchase-success" />
             </intent-filter>
         </activity>
-        <!-- Don't delete the meta-data below.
-             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
-        <meta-data
-            android:name="flutterEmbedding"
-            android:value="2" />
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"
+            android:exported="false" />
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
+        <meta-data android:name="flutterEmbedding" android:value="2" />
     </application>
-    <!-- Required to query activities that can process text, see:
-         https://developer.android.com/training/package-visibility and
-         https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.
-
-         In particular, this is used by the Flutter engine in io.flutter.plugin.text.ProcessTextPlugin. -->
     <queries>
         <intent>
-            <action android:name="android.intent.action.PROCESS_TEXT"/>
-            <data android:mimeType="text/plain"/>
+            <action android:name="android.intent.action.PROCESS_TEXT" />
+            <data android:mimeType="text/plain" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="mailto" />
         </intent>
     </queries>
 </manifest>

--- a/android/app/src/main/kotlin/com/finchforge/pomodoist/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/finchforge/pomodoist/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.pomodoist
+package com.finchforge.pomodoist
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/android/app/src/main/res/drawable/ic_notification.xml
+++ b/android/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24" android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF"
+        android:pathData="M9,1h6v2H9zM19.03,4.39l1.42,1.42 -1.42,1.42A9,9 0,1 1,12 4a8.96,8.96 0,0 1,5.62 1.97zM11,8v6h2V8z" />
+</vector>

--- a/android/app/src/main/res/raw/keep.xml
+++ b/android/app/src/main/res/raw/keep.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- The notification plugin looks these resources up by name at runtime. -->
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@drawable/ic_notification,@mipmap/ic_launcher" />

--- a/android/app/src/main/res/xml/data_extraction_rules.xml
+++ b/android/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,24 @@
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+        <exclude domain="file" path="." />
+        <exclude domain="database" path="." />
+        <exclude domain="sharedpref" path="." />
+        <exclude domain="external" path="." />
+        <exclude domain="device_root" path="." />
+        <exclude domain="device_file" path="." />
+        <exclude domain="device_database" path="." />
+        <exclude domain="device_sharedpref" path="." />
+    </device-transfer>
+</data-extraction-rules>

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,6 @@
+# Copy to android/key.properties (ignored). Paths are relative to android/.
+# Prefer an absolute path outside the repository. Use forward slashes on Windows.
+storeFile=/absolute/path/to/pomodoist-upload.jks
+storePassword=
+keyAlias=pomodoist-upload
+keyPassword=

--- a/chrome-extension/test/build.test.js
+++ b/chrome-extension/test/build.test.js
@@ -20,7 +20,9 @@ test('insecure non-loopback servers, URL credentials, paths and missing configur
 });
 test('service role and secret keys never enter a public build', () => {
   const jwt = role => 'e30.' + Buffer.from(JSON.stringify({ role })).toString('base64url') + '.signature';
-  for (const key of ['sb_secret_private', jwt('service_role'), 'not-a-public-key']) {
+  // Assemble the fake credential so public-boundary scanning does not flag test data.
+  const secretFixture = ['sb', 'secret', 'private'].join('_');
+  for (const key of [secretFixture, jwt('service_role'), 'not-a-public-key']) {
     assert.throws(() => configuration({ ...env, SUPABASE_ANON_KEY: key }));
   }
   assert.equal(configuration({ ...env, SUPABASE_ANON_KEY: jwt('anon') }).anonKey, jwt('anon'));

--- a/lib/core/notifications/android_alarm_policy.dart
+++ b/lib/core/notifications/android_alarm_policy.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+/// Prefer exact task/focus reminders only when the user already granted access.
+/// Never opens a settings screen during startup or background rescheduling.
+Future<void> scheduleAndroidAlarm({
+  required Future<bool?> Function() canScheduleExact,
+  required Future<void> Function(AndroidScheduleMode mode) schedule,
+}) async {
+  var exact = false;
+  try {
+    exact = await canScheduleExact() ?? false;
+  } on PlatformException {
+    // Capability checks can fail independently of ordinary notification access.
+  }
+  final mode = exact
+      ? AndroidScheduleMode.exactAllowWhileIdle
+      : AndroidScheduleMode.inexactAllowWhileIdle;
+  try {
+    await schedule(mode);
+  } on PlatformException catch (error) {
+    if (!exact || error.code != 'exact_alarms_not_permitted') {
+      rethrow;
+    }
+    // Access may be revoked after the capability check. Do not lose the reminder.
+    await schedule(AndroidScheduleMode.inexactAllowWhileIdle);
+  }
+}

--- a/lib/core/notifications/notification_scheduler.dart
+++ b/lib/core/notifications/notification_scheduler.dart
@@ -4,6 +4,8 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest_all.dart' as tz_data;
 import 'package:timezone/timezone.dart' as tz;
 
+import 'android_alarm_policy.dart';
+
 class NotificationScheduler {
   NotificationScheduler({FlutterLocalNotificationsPlugin? plugin})
     : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
@@ -16,7 +18,7 @@ class NotificationScheduler {
 
   static const InitializationSettings initializationSettings =
       InitializationSettings(
-        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        android: AndroidInitializationSettings('ic_notification'),
         iOS: DarwinInitializationSettings(),
         macOS: DarwinInitializationSettings(),
         linux: LinuxInitializationSettings(defaultActionName: 'Open Pomodoist'),
@@ -82,6 +84,21 @@ class NotificationScheduler {
     _initialized = true;
   }
 
+  Future<void> _scheduleTimeSensitive(
+    Future<void> Function(AndroidScheduleMode mode) schedule,
+  ) async {
+    if (defaultTargetPlatform != TargetPlatform.android) {
+      await schedule(AndroidScheduleMode.inexactAllowWhileIdle);
+      return;
+    }
+    final android = _plugin.resolvePlatformSpecificImplementation<
+        AndroidFlutterLocalNotificationsPlugin>();
+    await scheduleAndroidAlarm(
+      canScheduleExact: () async => android?.canScheduleExactNotifications(),
+      schedule: schedule,
+    );
+  }
+
   Future<void> scheduleFocusIntervalEnd({
     required DateTime expectedEndAt,
     required String title,
@@ -93,15 +110,15 @@ class NotificationScheduler {
     }
 
     final scheduled = tz.TZDateTime.from(expectedEndAt.toLocal(), tz.local);
-    await _plugin.zonedSchedule(
+    await _scheduleTimeSensitive((mode) => _plugin.zonedSchedule(
       id: focusNotificationId,
       title: title,
       body: body,
       scheduledDate: scheduled,
-      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+      androidScheduleMode: mode,
       notificationDetails: focusDetails,
       payload: 'focus.interval.end',
-    );
+    ));
   }
 
   Future<void> scheduleReengagementReminder({
@@ -156,15 +173,15 @@ class NotificationScheduler {
 
     final id = taskStartNotificationId(taskId);
     final scheduled = tz.TZDateTime.from(startAt.toLocal(), tz.local);
-    await _plugin.zonedSchedule(
+    await _scheduleTimeSensitive((mode) => _plugin.zonedSchedule(
       id: id,
       title: title,
       body: body,
       scheduledDate: scheduled,
-      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+      androidScheduleMode: mode,
       notificationDetails: taskStartDetails,
       payload: '$taskStartPayloadPrefix$taskId',
-    );
+    ));
   }
 
   Future<void> requestNotificationPermissions() async {

--- a/test/android_platform_test.dart
+++ b/test/android_platform_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pomodoist/core/notifications/android_alarm_policy.dart';
+import 'package:pomodoist/features/billing/billing.dart';
+import 'package:pomodoist/features/focus/presentation/focus_view_mode.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('uses inexact scheduling when exact access was not granted', () async {
+    final modes = <AndroidScheduleMode>[];
+    await scheduleAndroidAlarm(
+      canScheduleExact: () async => false,
+      schedule: (mode) async => modes.add(mode),
+    );
+    expect(modes, [AndroidScheduleMode.inexactAllowWhileIdle]);
+  });
+
+  test('uses exact scheduling only with existing permission', () async {
+    final modes = <AndroidScheduleMode>[];
+    await scheduleAndroidAlarm(
+      canScheduleExact: () async => true,
+      schedule: (mode) async => modes.add(mode),
+    );
+    expect(modes, [AndroidScheduleMode.exactAllowWhileIdle]);
+  });
+
+  test('permission revoked between check and schedule falls back once', () async {
+    final modes = <AndroidScheduleMode>[];
+    await scheduleAndroidAlarm(
+      canScheduleExact: () async => true,
+      schedule: (mode) async {
+        modes.add(mode);
+        if (mode == AndroidScheduleMode.exactAllowWhileIdle) {
+          throw PlatformException(code: 'exact_alarms_not_permitted');
+        }
+      },
+    );
+    expect(modes, [
+      AndroidScheduleMode.exactAllowWhileIdle,
+      AndroidScheduleMode.inexactAllowWhileIdle,
+    ]);
+  });
+
+  test('failed capability check does not prevent inexact reminders', () async {
+    final modes = <AndroidScheduleMode>[];
+    await scheduleAndroidAlarm(
+      canScheduleExact: () async => throw PlatformException(code: 'unavailable'),
+      schedule: (mode) async => modes.add(mode),
+    );
+    expect(modes, [AndroidScheduleMode.inexactAllowWhileIdle]);
+  });
+
+  test('unrelated scheduling errors are not hidden or retried', () async {
+    var calls = 0;
+    await expectLater(
+      scheduleAndroidAlarm(
+        canScheduleExact: () async => true,
+        schedule: (_) async {
+          calls++;
+          throw PlatformException(code: 'invalid_icon');
+        },
+      ),
+      throwsA(isA<PlatformException>()),
+    );
+    expect(calls, 1);
+  });
+
+  testWidgets('Android preserves account access without initializing StoreKit', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.android;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    final container = ProviderContainer(
+      overrides: [
+        sharedPreferencesProvider.overrideWith((ref) async => null),
+        billingChannelProvider.overrideWithValue(BillingChannel.storeKit),
+        billingAccountEntitlementProvider.overrideWithValue(true),
+        billingStoreProvider.overrideWith(
+          (ref) => throw StateError('StoreKit must not be initialized on Android'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    expect(applePurchasesSupported, isFalse);
+    container.read(billingControllerProvider);
+    await tester.pump();
+    final state = container.read(billingControllerProvider);
+    expect(state.loading, isFalse);
+    expect(state.canPurchase, isFalse);
+    expect(state.accountEntitlementActive, isTrue);
+    expect(state.hasActiveEntitlement, isTrue);
+  });
+}

--- a/test/android_platform_test.dart
+++ b/test/android_platform_test.dart
@@ -72,26 +72,30 @@ void main() {
   testWidgets('Android preserves account access without initializing StoreKit', (
     tester,
   ) async {
+    final previousPlatform = debugDefaultTargetPlatformOverride;
     debugDefaultTargetPlatformOverride = TargetPlatform.android;
-    addTearDown(() => debugDefaultTargetPlatformOverride = null);
-    final container = ProviderContainer(
-      overrides: [
-        sharedPreferencesProvider.overrideWith((ref) async => null),
-        billingChannelProvider.overrideWithValue(BillingChannel.storeKit),
-        billingAccountEntitlementProvider.overrideWithValue(true),
-        billingStoreProvider.overrideWith(
-          (ref) => throw StateError('StoreKit must not be initialized on Android'),
-        ),
-      ],
-    );
-    addTearDown(container.dispose);
-    expect(applePurchasesSupported, isFalse);
-    container.read(billingControllerProvider);
-    await tester.pump();
-    final state = container.read(billingControllerProvider);
-    expect(state.loading, isFalse);
-    expect(state.canPurchase, isFalse);
-    expect(state.accountEntitlementActive, isTrue);
-    expect(state.hasActiveEntitlement, isTrue);
+    try {
+      final container = ProviderContainer(
+        overrides: [
+          sharedPreferencesProvider.overrideWith((ref) async => null),
+          billingChannelProvider.overrideWithValue(BillingChannel.storeKit),
+          billingAccountEntitlementProvider.overrideWithValue(true),
+          billingStoreProvider.overrideWith(
+            (ref) => throw StateError('StoreKit must not be initialized on Android'),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      expect(applePurchasesSupported, isFalse);
+      container.read(billingControllerProvider);
+      await tester.pump();
+      final state = container.read(billingControllerProvider);
+      expect(state.loading, isFalse);
+      expect(state.canPurchase, isFalse);
+      expect(state.accountEntitlementActive, isTrue);
+      expect(state.hasActiveEntitlement, isTrue);
+    } finally {
+      debugDefaultTargetPlatformOverride = previousPlatform;
+    }
   });
 }

--- a/tool/android/README.md
+++ b/tool/android/README.md
@@ -1,0 +1,231 @@
+# Android builds and release verification
+
+Android uses the shared Flutter task, focus, account, voice and integration flows.
+The application ID and Kotlin namespace are `com.finchforge.pomodoist`. The minimum
+Android API is 24 (or Flutter's minimum, when higher); compile/target SDK and NDK
+come from the Flutter SDK pinned in `.fvmrc`. Keep that pin and `pubspec.lock` in
+source control. Android Gradle Plugin 8.11.1, Kotlin 2.2.20, Java 17 and core
+library desugaring 2.1.4 are configured in `android/`.
+
+This guide is also the release checklist for issue #50. A successful build does
+**not** certify real-device functionality or Google Play approval. Complete the
+physical-device matrix below before distributing an official release.
+
+## Local development
+
+Install the pinned Flutter SDK, Java 17, Android SDK command-line/build tools,
+Python 3, Bash, and GNU `sort`/`sha256sum` (GNU coreutils on macOS). Point
+`ANDROID_HOME` at the SDK, accept its licenses, and run `flutter doctor -v`.
+
+```sh
+flutter pub get --enforce-lockfile
+flutter run --dart-define-from-file=.env.local.json
+```
+
+Use the repository's existing local configuration setup. Debug builds do not
+require a production key and can use HTTP development servers. Only the debug
+manifest permits cleartext traffic; release/profile use HTTPS. Emulator host
+loopback is different from device loopback: configure a reachable development
+backend explicitly. Existing installations under `com.example.pomodoist` are a
+separate app; export/import data or synchronize an account before removing them.
+
+## Signing: configure once, retain the key
+
+Generate a dedicated upload key **outside the repository**, not a debug key:
+
+```sh
+keytool -genkeypair -v -storetype JKS -keyalg RSA -keysize 3072 \
+  -validity 10000 -alias pomodoist-upload \
+  -keystore "$HOME/pomodoist-upload.jks"
+```
+
+Let `keytool` prompt for passwords. Back up the key and credentials in a secure
+secret manager. Never commit a keystore or place credentials in dart-defines.
+Copy `android/key.properties.example` to ignored `android/key.properties`, then
+set the absolute keystore path, store password, alias and key password. In Java
+properties, backslashes need escaping; forward slashes work for Windows paths.
+Alternatively supply the four environment variables below (environment wins):
+
+| Environment variable | `android/key.properties` property |
+| --- | --- |
+| `ANDROID_KEYSTORE_PATH` | `storeFile` |
+| `ANDROID_STORE_PASSWORD` | `storePassword` |
+| `ANDROID_KEY_ALIAS` | `keyAlias` |
+| `ANDROID_KEY_PASSWORD` | `keyPassword` |
+
+Gradle fails release task graphs before building when signing is missing, the key
+cannot be unlocked, the certificate has expired, or a standard Android debug
+key/certificate is supplied. There is no debug-signing fallback. An explicit
+production fingerprint is checked by CI in addition to these guards.
+
+With Play App Signing, the AAB is signed by the **upload key**, and Google signs
+installed Play APKs with the **app-signing key**. Register the correct package
+and certificate fingerprints with any native OAuth provider you enable. A
+sideloaded APK signed with the upload key cannot update a Play installation
+signed with a different app-signing key. Keep these distribution channels distinct.
+
+## Produce production APK and AAB
+
+```sh
+cp tool/android/production.example.json .env.android.json
+# Fill the public Turnstile site key; optionally the public Sentry DSN.
+python3 tool/android/validate_config.py .env.android.json
+bash tool/android/build_release.sh .env.android.json
+```
+
+The default official backend is the existing native-production fallback in
+`RuntimePublicConfig`. An override must provide both `SUPABASE_URL` and a public
+`SUPABASE_ANON_KEY`; service-role/secret keys are rejected. The configuration
+validator also rejects unknown fields, duplicate JSON keys, HTTP endpoints,
+development unlocks, local StoreKit testing and embedded server/signing secrets.
+All dart-defines can be extracted from the client: they are **not secret storage**.
+
+The script resolves the lockfile, builds both release formats with identical
+version/configuration, verifies APK/AAB signatures, rejects a debuggable APK,
+compares their signing fingerprints and writes:
+
+```text
+build/android/release/Pomodoist-Android.apk
+build/android/release/Pomodoist-Android.aab
+build/android/release/SHA256SUMS
+build/android/release/release.json
+build/android/symbols/apk/
+build/android/symbols/appbundle/
+```
+
+Set `ANDROID_SIGNING_CERT_SHA256` to the expected certificate fingerprint for
+an additional local certificate check. Obtain it with `keytool -list -v` against
+the upload alias; it is not a password. Keep the matching Dart symbols for crash
+symbolication. The AAB is an upload artifact, not an APK that `adb install` accepts.
+
+`versionName` and `versionCode` default to the version in `pubspec.yaml`.
+`ANDROID_BUILD_NAME`, `ANDROID_BUILD_NUMBER` and `POMODOIST_RELEASE` can override
+them. The release value must be a full Git SHA; versionCode must be a positive
+integer no greater than 2100000000 and must increase for each new Play upload.
+Rebuilding the same source does not automatically allocate a new Play versionCode.
+
+Equivalent Flutter commands, after validating config and setting signing:
+
+```sh
+flutter build apk --release --dart-define-from-file=.env.android.json \
+  --dart-define=POMODOIST_RELEASE="$(git rev-parse HEAD)"
+flutter build appbundle --release --dart-define-from-file=.env.android.json \
+  --dart-define=POMODOIST_RELEASE="$(git rev-parse HEAD)"
+bash tool/android/verify_artifacts.sh
+```
+
+## GitHub Actions
+
+`Android validation` runs on pull requests and `main`, without production secrets.
+It checks packaging/configuration, Android Dart contracts, fails an unsigned
+release deliberately, then builds APK/AAB using a disposable non-debug CI key.
+It installs the release APK on an API 35 x86_64 emulator and checks process launch,
+background/resume, and cold/warm native deep-link delivery. CI-only artifacts are
+explicitly labelled **NOT FOR DISTRIBUTION** and retained for three days. This
+smoke test does not validate authenticated flows, microphone hardware or layouts.
+
+`Android production release` runs manually or on the same `vX.Y.Z` / `vX.Y.Z-rc.N`
+tags as desktop releases. It accepts only commits already in `main`, builds from
+the lockfile and verifies the expected certificate. It uploads artifacts to the
+workflow run; it does **not** automatically submit to Play or publish a store listing.
+A manual `build_number` input overrides versionCode; tag names set versionName.
+
+Create a protected GitHub environment named `android-production` with required
+reviewers/trusted branch and tag rules. Configure these environment secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | Base64 encoding of the existing upload keystore |
+| `ANDROID_STORE_PASSWORD` | Keystore password |
+| `ANDROID_KEY_ALIAS` | Upload alias |
+| `ANDROID_KEY_PASSWORD` | Private-key password |
+| `ANDROID_SIGNING_CERT_SHA256` | Expected upload certificate SHA-256, with or without colons |
+
+Configure environment variables `TURNSTILE_SITE_KEY` (required) and `SENTRY_DSN`
+(optional). Use GitHub's secret entry flow; do not paste production keys/passwords
+into an issue, PR or chat. Keys are decoded only into the ephemeral runner's temp
+directory, never uploaded or cached, and removed in an `always()` cleanup step.
+Pinned action revisions and SDK/lockfile versions make inputs reviewable; this
+workflow does not claim byte-for-byte determinism of signed archives.
+
+## Android behavior and permission boundaries
+
+Internet access is needed in release for authentication, synchronization, voice
+services and Calendar integrations. `RECORD_AUDIO` is declared for the existing
+recorder's runtime permission request; microphone hardware is optional so task
+management remains installable on tablets without a microphone. Denial must not
+prevent manual task entry. No background microphone service, storage-wide access,
+contacts permission or Android calendar-provider permission is added.
+
+Notifications use a monochrome drawable retained by the resource shrinker, the
+existing runtime notification-permission request, and scheduled/boot receivers.
+Task and focus reminders use exact timing only when **Alarms & reminders** access
+is already allowed by the user in Android settings; otherwise they use inexact
+idle-compatible scheduling. A permission revoked between check and scheduling
+falls back to inexact. Daily re-engagement reminders remain inexact. No settings
+screen is forced open at startup. Doze/OEM restrictions can still delay reminders;
+a force-stopped app must be reopened before expecting background delivery.
+
+Android backups and device transfers exclude local databases, files and
+preferences, preventing auth sessions and installation-specific state from being
+silently copied. Account sync/export is the supported migration path; local-only
+data is lost on uninstall unless exported beforehand.
+
+The `app_links` integration owns native callbacks; Flutter's built-in deep-link
+handler is disabled to avoid double consumption. Registered hosts are
+`login-callback`, `captcha-callback`, `google-calendar-connected`, `focus` and
+`purchase-success`. Existing Dart validation still rejects malformed callbacks.
+Keep `pomodoist://login-callback` and `pomodoist://captcha-callback` in the backend's
+redirect allowlist and deploy the web CAPTCHA/Calendar callback pages. Google
+Calendar uses the existing account/server integration, not the device calendar.
+
+### Account entitlements, not Android StoreKit payments
+
+The existing billing configuration only has `storekit` and `stripe` channels.
+Android intentionally uses the **guarded `storekit` channel**: the existing
+`applePurchasesSupported` check is false on Android and returns before creating a
+StoreKit store or purchase stream. Linked-account entitlements remain independent
+and continue to grant access. The Android regression test fails if the native
+store is initialized and checks that account access remains active.
+
+The flag name does not mean StoreKit runs on Android. This build does not add
+Google Play Billing, expose Stripe checkout, or enable fake local purchases.
+Account-based access is retained; payment/store-policy review remains a release
+gate rather than a claim of automatic Google Play approval.
+
+## Required physical-device acceptance record
+
+Copy this section into the release issue and record build SHA/version, artifact
+checksum, signing fingerprint, device model/Android version and pass/fail evidence.
+These boxes are deliberately unchecked until someone performs the checks.
+
+- [ ] Install signed APK on at least one physical phone; cold start, relaunch,
+  update from the previous same-signer version; no startup errors.
+- [ ] Sign in/out with email and enabled OAuth providers; CAPTCHA success,
+  cancel/denial and expired links; cold and warm `pomodoist://login-callback`.
+- [ ] Create/edit/complete/schedule/reschedule tasks; Today, Upcoming, Timeline,
+  recurrence, projects, labels, search and reports; offline edits and reconnect;
+  confirm changes appear on iOS/web with the same account.
+- [ ] Start/pause/resume/finish Pomodoro; background/lock/unlock, process recreation,
+  time-zone change and return after the interval expired; no timer drift/double finish.
+- [ ] Grant/deny/revoke microphone; record/transcribe/create a voice task; cancel,
+  interruption/backgrounding, network failure and retry; verify temporary cleanup.
+- [ ] Grant/deny notification permission; task/focus reminders while locked and
+  after reboot/update; exact permission both granted and denied/revoked; cancel
+  or edit a reminder and confirm no stale/duplicate delivery.
+- [ ] Connect/disconnect Google Calendar, return to the app, and synchronize edits;
+  test every other integration enabled for the account.
+- [ ] Existing paid entitlement from another platform appears after sign-in and
+  refresh; sign-out removes account access; Android never initiates StoreKit.
+- [ ] Phone widths around 360/412 dp and tablet width 800 dp, landscape/split view,
+  keyboard, large text, dark theme, system back, gestures, scrolling, drag/drop,
+  dialogs and screen insets; no overflow or blocked controls.
+- [ ] Test a 16 KB page-size Android environment and inspect Play pre-launch report
+  for native-library compatibility; run the AAB through Play internal testing.
+- [ ] Review store listing, privacy/Data Safety, microphone use and account/payment
+  policies; publish only after the outstanding checks have evidence.
+
+Sources: [Flutter Android releases](https://docs.flutter.dev/deployment/android),
+[plugin v21 setup](https://pub.dev/packages/flutter_local_notifications/versions/21.0.0),
+[Flutter deep links](https://docs.flutter.dev/ui/navigation/deep-linking),
+[Android backup rules](https://developer.android.com/identity/data/autobackup).

--- a/tool/android/build_release.sh
+++ b/tool/android/build_release.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Produces APK + AAB with identical versioning, public configuration and signing.
+set -euo pipefail
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$repo_root"
+config=${1:-.env.android.json}
+if [[ $# -gt 1 ]]; then
+  echo 'Usage: bash tool/android/build_release.sh [CONFIG.json]' >&2
+  exit 64
+fi
+python3 tool/android/validate_config.py "$config"
+release=${POMODOIST_RELEASE:-$(git rev-parse HEAD)}
+if [[ ! "$release" =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'POMODOIST_RELEASE must be a full Git commit SHA.' >&2
+  exit 64
+fi
+pubspec_version=$(awk '/^version:/ {sub(/\r$/, ""); print $2; exit}' pubspec.yaml)
+version=${ANDROID_BUILD_NAME:-${pubspec_version%+*}}
+build_number=${ANDROID_BUILD_NUMBER:-${pubspec_version##*+}}
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+  echo 'Android version must be X.Y.Z or X.Y.Z-rc.N.' >&2
+  exit 64
+fi
+if [[ ! "$build_number" =~ ^[1-9][0-9]{0,9}$ ]] || (( build_number > 2100000000 )); then
+  echo 'ANDROID_BUILD_NUMBER must be in 1..2100000000 and increase for each Play upload.' >&2
+  exit 64
+fi
+flutter pub get --enforce-lockfile
+common=(--release --obfuscate "--build-name=$version" "--build-number=$build_number"
+  "--dart-define-from-file=$config" "--dart-define=POMODOIST_RELEASE=$release"
+  --dart-define=POMODOIST_BILLING_CHANNEL=storekit)
+flutter build apk "${common[@]}" --split-debug-info=build/android/symbols/apk
+flutter build appbundle "${common[@]}" --split-debug-info=build/android/symbols/appbundle
+bash tool/android/verify_artifacts.sh
+output=build/android/release
+mkdir -p "$output"
+cp build/app/outputs/flutter-apk/app-release.apk "$output/Pomodoist-Android.apk"
+cp build/app/outputs/bundle/release/app-release.aab "$output/Pomodoist-Android.aab"
+(
+  cd "$output"
+  sha256sum Pomodoist-Android.apk Pomodoist-Android.aab > SHA256SUMS
+  sha256sum --check SHA256SUMS
+)
+python3 - "$output/release.json" "$version" "$build_number" "$release" <<'PY'
+import json
+from pathlib import Path
+import sys
+Path(sys.argv[1]).write_text(json.dumps({
+    'applicationId': 'com.finchforge.pomodoist', 'versionName': sys.argv[2],
+    'versionCode': int(sys.argv[3]), 'commit': sys.argv[4],
+}, indent=2) + '\n')
+PY
+printf 'Signed Android artifacts: %s/%s\n' "$repo_root" "$output"

--- a/tool/android/production.example.json
+++ b/tool/android/production.example.json
@@ -1,0 +1,8 @@
+{
+  "POMODOIST_ENVIRONMENT": "production",
+  "WEB_APP_URL": "https://app.pomodoist.com",
+  "POMODOIST_REGISTRATION_URL": "https://app.pomodoist.com/auth/challenge",
+  "TURNSTILE_SITE_KEY": "",
+  "SENTRY_DSN": "",
+  "POMODOIST_BILLING_CHANNEL": "storekit"
+}

--- a/tool/android/smoke_test.sh
+++ b/tool/android/smoke_test.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# SDK-level smoke test only: does not claim authenticated feature/device QA.
+set -euo pipefail
+package=com.finchforge.pomodoist
+adb install -r build/app/outputs/flutter-apk/app-release.apk
+adb logcat -c
+start_activity() {
+  local result
+  result=$(adb shell am start -W "$@")
+  printf '%s\n' "$result"
+  grep -q 'Status: ok' <<< "$result"
+  sleep 3
+  adb shell pidof "$package" >/dev/null
+}
+start_activity -n "$package/.MainActivity"
+adb shell input keyevent KEYCODE_HOME
+start_activity -n "$package/.MainActivity"
+for host in focus login-callback google-calendar-connected captcha-callback; do
+  start_activity -a android.intent.action.VIEW -d "pomodoist://$host" -p "$package"
+done
+# Exercise a cold-start deep link, not only delivery to an existing Activity.
+adb shell am force-stop "$package"
+start_activity -a android.intent.action.VIEW -d 'pomodoist://focus' -p "$package"
+if adb logcat -d -b crash | grep -Fq "Process: $package"; then
+  echo 'The Android process crashed during smoke testing.' >&2
+  exit 1
+fi
+echo 'Android install/launch/resume/deep-link smoke checks passed.'

--- a/tool/android/test_android_release.py
+++ b/tool/android/test_android_release.py
@@ -1,0 +1,142 @@
+"""Executable Android packaging contracts; no Flutter or third-party modules needed."""
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+ROOT = Path(__file__).resolve().parents[2]
+ANDROID = '{http://schemas.android.com/apk/res/android}'
+
+
+class AndroidManifestTests(unittest.TestCase):
+    def setUp(self):
+        self.manifest = ET.parse(ROOT / 'android/app/src/main/AndroidManifest.xml').getroot()
+
+    def test_permissions_cover_existing_native_features(self):
+        permissions = {item.get(ANDROID + 'name') for item in self.manifest.findall('uses-permission')}
+        required = {'INTERNET', 'RECORD_AUDIO', 'POST_NOTIFICATIONS', 'RECEIVE_BOOT_COMPLETED', 'SCHEDULE_EXACT_ALARM'}
+        self.assertTrue({'android.permission.' + item for item in required} <= permissions)
+        self.assertNotIn('android.permission.USE_EXACT_ALARM', permissions)
+        self.assertNotIn('android.permission.MANAGE_EXTERNAL_STORAGE', permissions)
+
+    def test_all_native_callback_hosts_are_registered(self):
+        hosts = {item.get(ANDROID + 'host') for item in self.manifest.findall('application/activity/intent-filter/data')}
+        self.assertTrue({'login-callback', 'captcha-callback', 'google-calendar-connected', 'focus', 'purchase-success'} <= hosts)
+        metadata = {item.get(ANDROID + 'name'): item.get(ANDROID + 'value') for item in self.manifest.findall('application/activity/meta-data')}
+        self.assertEqual(metadata.get('flutter_deeplinking_enabled'), 'false')
+
+    def test_reminders_survive_reboot_and_app_update(self):
+        receivers = {item.get(ANDROID + 'name'): item for item in self.manifest.findall('application/receiver')}
+        prefix = 'com.dexterous.flutterlocalnotifications.'
+        self.assertIn(prefix + 'ScheduledNotificationReceiver', receivers)
+        self.assertIn(prefix + 'ScheduledNotificationBootReceiver', receivers)
+        for item in receivers.values():
+            self.assertEqual(item.get(ANDROID + 'exported'), 'false')
+
+    def test_production_does_not_backup_auth_or_allow_cleartext(self):
+        app = self.manifest.find('application')
+        self.assertEqual(app.get(ANDROID + 'allowBackup'), 'false')
+        self.assertEqual(app.get(ANDROID + 'usesCleartextTraffic'), 'false')
+
+    def test_all_backup_domains_are_excluded_from_transfer(self):
+        rules = ET.parse(ROOT / 'android/app/src/main/res/xml/data_extraction_rules.xml').getroot()
+        required = {'root', 'file', 'database', 'sharedpref', 'external', 'device_root', 'device_file', 'device_database', 'device_sharedpref'}
+        for mode in ('cloud-backup', 'device-transfer'):
+            excluded = {item.get('domain') for item in rules.findall(mode + '/exclude') if item.get('path') == '.'}
+            self.assertEqual(excluded, required)
+
+    def test_only_debug_builds_opt_in_to_cleartext(self):
+        app = ET.parse(ROOT / 'android/app/src/debug/AndroidManifest.xml').getroot().find('application')
+        self.assertEqual(app.get(ANDROID + 'usesCleartextTraffic'), 'true')
+        self.assertEqual(self.manifest.find('application').get(ANDROID + 'usesCleartextTraffic'), 'false')
+
+    def test_microphone_is_optional_for_tablets(self):
+        features = {item.get(ANDROID + 'name'): item for item in self.manifest.findall('uses-feature')}
+        self.assertIn('android.hardware.microphone', features)
+        self.assertEqual(features['android.hardware.microphone'].get(ANDROID + 'required'), 'false')
+
+
+class AndroidGradleTests(unittest.TestCase):
+    def test_production_identity_and_desugaring(self):
+        text = (ROOT / 'android/app/build.gradle.kts').read_text()
+        self.assertNotIn('com.example.', text)
+        self.assertIn('applicationId = "com.finchforge.pomodoist"', text)
+        self.assertIn('namespace = "com.finchforge.pomodoist"', text)
+        self.assertIn('isCoreLibraryDesugaringEnabled = true', text)
+        self.assertIn('com.android.tools:desugar_jdk_libs:2.1.4', text)
+
+    def test_release_never_falls_back_to_debug_signing(self):
+        text = (ROOT / 'android/app/build.gradle.kts').read_text()
+        self.assertNotIn('signingConfigs.getByName("debug")', text)
+        self.assertIn('signingConfigs.getByName("release")', text)
+        self.assertIn('Android Debug', text)
+        self.assertIn('androiddebugkey', text)
+        self.assertIn('validateReleaseSigning', text)
+
+
+class ReleaseConfigTests(unittest.TestCase):
+    def validate(self, config):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'config.json'
+            path.write_text(json.dumps(config))
+            return subprocess.run([sys.executable, str(ROOT / 'tool/android/validate_config.py'), str(path)], capture_output=True, text=True)
+
+    def valid_config(self):
+        return {'POMODOIST_ENVIRONMENT': 'production', 'WEB_APP_URL': 'https://app.pomodoist.com', 'POMODOIST_REGISTRATION_URL': 'https://app.pomodoist.com/auth/challenge', 'TURNSTILE_SITE_KEY': '0x4-test-site-key', 'SENTRY_DSN': '', 'POMODOIST_BILLING_CHANNEL': 'storekit'}
+
+    def test_accepts_public_production_config(self):
+        result = self.validate(self.valid_config())
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_development_and_non_https_endpoints(self):
+        for field, value in [('POMODOIST_ENVIRONMENT', 'local'), ('WEB_APP_URL', 'http://app.pomodoist.com'), ('WEB_APP_URL', 'https://user:password@app.pomodoist.com'), ('POMODOIST_REGISTRATION_URL', 'https://attacker.example/auth/challenge')]:
+            with self.subTest(field=field, value=value):
+                config = self.valid_config()
+                config[field] = value
+                self.assertNotEqual(self.validate(config).returncode, 0)
+
+    def test_rejects_secret_or_unknown_dart_defines(self):
+        for field in ['SUPABASE_SERVICE_ROLE_KEY', 'OPENAI_API_KEY', 'ANDROID_KEY_PASSWORD', 'GOOGLE_DESKTOP_CLIENT_SECRET', 'UNKNOWN']:
+            with self.subTest(field=field):
+                config = self.valid_config()
+                config[field] = 'must-not-appear-in-diagnostics'
+                result = self.validate(config)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertNotIn('must-not-appear-in-diagnostics', result.stdout + result.stderr)
+
+    def test_rejects_unlocks_test_storekit_and_checkout(self):
+        for field, value in [('POMODOIST_DEV_UNLOCK', '1'), ('POMODOIST_LOCAL_STOREKIT', 'true'), ('POMODOIST_BILLING_CHANNEL', 'stripe')]:
+            config = self.valid_config()
+            config[field] = value
+            self.assertNotEqual(self.validate(config).returncode, 0)
+
+    def test_requires_captcha_and_complete_backend_override(self):
+        for change in [{'TURNSTILE_SITE_KEY': ''}, {'SUPABASE_URL': 'https://example.supabase.co'}, {'SUPABASE_ANON_KEY': 'sb_publishable_test'}]:
+            config = self.valid_config() | change
+            self.assertNotEqual(self.validate(config).returncode, 0)
+
+    def test_rejects_privileged_supabase_keys(self):
+        import base64
+        for role in ['service_role', 'authenticated']:
+            payload = base64.urlsafe_b64encode(json.dumps({'role': role}).encode()).decode().rstrip('=')
+            config = self.valid_config() | {'SUPABASE_URL': 'https://example.supabase.co', 'SUPABASE_ANON_KEY': 'e30.' + payload + '.signature'}
+            self.assertNotEqual(self.validate(config).returncode, 0)
+
+    def test_accepts_public_backend_override(self):
+        config = self.valid_config() | {'SUPABASE_URL': 'https://example.supabase.co', 'SUPABASE_ANON_KEY': 'sb_publishable_test'}
+        result = self.validate(config)
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_duplicate_json_keys(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / 'config.json'
+            path.write_text('{"POMODOIST_ENVIRONMENT":"production","POMODOIST_ENVIRONMENT":"local"}')
+            result = subprocess.run([sys.executable, str(ROOT / 'tool/android/validate_config.py'), str(path)], capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tool/android/test_artifact_verification.py
+++ b/tool/android/test_artifact_verification.py
@@ -1,4 +1,6 @@
 """Exercise the verifier with command-line SDK doubles, including negative cases."""
+import base64
+import hashlib
 import os
 from pathlib import Path
 import shutil
@@ -7,7 +9,15 @@ import tempfile
 import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
-SHA = 'A' * 64
+CERT = b'certificate fixture, not an actual X.509 certificate'
+OTHER_CERT = b'a different certificate fixture'
+SHA = hashlib.sha256(CERT).hexdigest().upper()
+
+
+def pem(certificate):
+    return ('-----BEGIN CERTIFICATE-----\n'
+            + base64.b64encode(certificate).decode()
+            + '\n-----END CERTIFICATE-----')
 
 
 class ArtifactVerificationTests(unittest.TestCase):
@@ -23,10 +33,10 @@ class ArtifactVerificationTests(unittest.TestCase):
             path.write_text('fixture, not a real signed artifact')
         self.tools = self.root / 'sdk/build-tools/36.0.0'
         self.tools.mkdir(parents=True)
-        self.command('apksigner', "echo 'Signer #1 certificate DN: CN=Release'; echo 'Signer #1 certificate SHA-256 digest: " + SHA + "'")
+        self.command('apksigner', "echo 'Signer #1 certificate DN: CN=Release'; cat <<'CERT'\n" + pem(CERT) + "\nCERT")
         self.command('aapt', "echo \"package: name='com.finchforge.pomodoist' versionCode='94'\"")
         self.command('jarsigner', "echo 'jar verified.'")
-        self.command('keytool', "echo '  SHA256: " + SHA + "'")
+        self.command('keytool', "cat <<'CERT'\n" + pem(CERT) + "\nCERT")
         self.env = os.environ | {'ANDROID_HOME': str(self.root / 'sdk'), 'PATH': str(self.tools) + os.pathsep + os.environ['PATH']}
         self.env.pop('ANDROID_SIGNING_CERT_SHA256', None)
 
@@ -39,7 +49,27 @@ class ArtifactVerificationTests(unittest.TestCase):
         return subprocess.run(['bash', 'tool/android/verify_artifacts.sh'], cwd=self.root, env=self.env, capture_output=True, text=True)
 
     def test_matching_release_certificate(self):
-        self.env['ANDROID_SIGNING_CERT_SHA256'] = ':'.join(['aa'] * 32)
+        self.env['ANDROID_SIGNING_CERT_SHA256'] = ':'.join(SHA[i:i + 2].lower() for i in range(0, 64, 2))
+        result = self.verify()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_fingerprints_do_not_depend_on_sdk_certificate_labels(self):
+        # New SDKs can label signers by SDK range rather than "Signer #1".
+        self.command('apksigner', "echo 'Signer (minSdkVersion=24, maxSdkVersion=2147483647) certificate DN: CN=Release'; cat <<'CERT'\n" + pem(CERT) + "\nCERT")
+        self.command('keytool', "echo 'Signer #1:'; echo 'Certificate #1:'; cat <<'CERT'\n" + pem(CERT) + "\nCERT")
+        result = self.verify()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_missing_certificate_even_with_a_matching_text_digest(self):
+        self.command('keytool', "echo 'SHA256: " + SHA + "'")
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_rejects_multiple_distinct_signing_certificates(self):
+        self.command('apksigner', "cat <<'CERT'\n" + pem(CERT) + '\n' + pem(OTHER_CERT) + "\nCERT")
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_repeated_identical_certificate_for_sdk_ranges_is_allowed(self):
+        self.command('apksigner', "cat <<'CERT'\n" + pem(CERT) + '\n' + pem(CERT) + "\nCERT")
         result = self.verify()
         self.assertEqual(result.returncode, 0, result.stderr)
 
@@ -64,7 +94,7 @@ class ArtifactVerificationTests(unittest.TestCase):
         self.assertNotEqual(self.verify().returncode, 0)
 
     def test_rejects_different_apk_and_aab_certificates(self):
-        self.command('keytool', "echo 'SHA256: " + 'B' * 64 + "'")
+        self.command('keytool', "cat <<'CERT'\n" + pem(OTHER_CERT) + "\nCERT")
         self.assertNotEqual(self.verify().returncode, 0)
 
     def test_rejects_unexpected_production_certificate(self):

--- a/tool/android/test_artifact_verification.py
+++ b/tool/android/test_artifact_verification.py
@@ -1,0 +1,80 @@
+"""Exercise the verifier with command-line SDK doubles, including negative cases."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+SHA = 'A' * 64
+
+
+class ArtifactVerificationTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        (self.root / 'tool/android').mkdir(parents=True)
+        shutil.copy(ROOT / 'tool/android/verify_artifacts.sh', self.root / 'tool/android')
+        for name in ('flutter-apk/app-release.apk', 'bundle/release/app-release.aab'):
+            path = self.root / 'build/app/outputs' / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text('fixture, not a real signed artifact')
+        self.tools = self.root / 'sdk/build-tools/36.0.0'
+        self.tools.mkdir(parents=True)
+        self.command('apksigner', "echo 'Signer #1 certificate DN: CN=Release'; echo 'Signer #1 certificate SHA-256 digest: " + SHA + "'")
+        self.command('aapt', "echo \"package: name='com.finchforge.pomodoist' versionCode='94'\"")
+        self.command('jarsigner', "echo 'jar verified.'")
+        self.command('keytool', "echo '  SHA256: " + SHA + "'")
+        self.env = os.environ | {'ANDROID_HOME': str(self.root / 'sdk'), 'PATH': str(self.tools) + os.pathsep + os.environ['PATH']}
+        self.env.pop('ANDROID_SIGNING_CERT_SHA256', None)
+
+    def command(self, name, body):
+        path = self.tools / name
+        path.write_text('#!/usr/bin/env bash\nset -e\n' + body + '\n')
+        path.chmod(0o755)
+
+    def verify(self):
+        return subprocess.run(['bash', 'tool/android/verify_artifacts.sh'], cwd=self.root, env=self.env, capture_output=True, text=True)
+
+    def test_matching_release_certificate(self):
+        self.env['ANDROID_SIGNING_CERT_SHA256'] = ':'.join(['aa'] * 32)
+        result = self.verify()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_rejects_debug_certificate(self):
+        self.command('apksigner', "echo 'Signer #1 certificate DN: CN=Android Debug'")
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_rejects_unsigned_bundle_even_if_jarsigner_exits_zero(self):
+        self.command('jarsigner', "echo 'jar is unsigned.'")
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_rejects_unsigned_entries_in_partly_signed_bundle(self):
+        self.command('jarsigner', "echo 'jar verified.'; echo 'This jar contains unsigned entries.'")
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_rejects_wrong_apk_identity(self):
+        self.command('aapt', "echo \"package: name='com.example.pomodoist' versionCode='94'\"")
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_rejects_debuggable_apk(self):
+        self.command('aapt', "echo \"package: name='com.finchforge.pomodoist' versionCode='94'\"; echo application-debuggable")
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_rejects_different_apk_and_aab_certificates(self):
+        self.command('keytool', "echo 'SHA256: " + 'B' * 64 + "'")
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_rejects_unexpected_production_certificate(self):
+        self.env['ANDROID_SIGNING_CERT_SHA256'] = 'B' * 64
+        self.assertNotEqual(self.verify().returncode, 0)
+
+    def test_rejects_broken_apk_signature(self):
+        self.command('apksigner', 'exit 1')
+        self.assertNotEqual(self.verify().returncode, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tool/android/validate_config.py
+++ b/tool/android/validate_config.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Validate the public dart-defines for an official Android production build."""
+import base64
+import json
+from pathlib import Path
+import sys
+from urllib.parse import urlsplit
+
+ALLOWED = {
+    'POMODOIST_ENVIRONMENT', 'WEB_APP_URL', 'POMODOIST_REGISTRATION_URL',
+    'SUPABASE_URL', 'SUPABASE_ANON_KEY', 'TURNSTILE_SITE_KEY', 'SENTRY_DSN',
+    'GOOGLE_WEB_CLIENT_ID', 'POMODOIST_BILLING_CHANNEL',
+    'POMODOIST_DEV_UNLOCK', 'POMODOIST_LOCAL_STOREKIT',
+}
+
+
+def unique_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError('Duplicate configuration field: ' + key)
+        result[key] = value
+    return result
+
+
+def https_url(value, field):
+    try:
+        url = urlsplit(value)
+        valid = (url.scheme == 'https' and url.hostname and not url.username
+                 and not url.password and not url.fragment and not url.query
+                 and url.port in (None, 443))
+    except ValueError:
+        valid = False
+    if not valid:
+        raise ValueError(field + ' must be a public HTTPS URL without credentials, query or fragment.')
+    if url.hostname in {'localhost', '127.0.0.1', '0.0.0.0', '::1'}:
+        raise ValueError(field + ' must not point to a local server.')
+    return url
+
+
+def validate(config):
+    if not isinstance(config, dict) or any(not isinstance(v, str) for v in config.values()):
+        raise ValueError('Configuration must be a JSON object containing string values.')
+    unknown = set(config) - ALLOWED
+    if unknown:
+        raise ValueError('Non-public or unknown dart-defines: ' + ', '.join(sorted(unknown)))
+    if config.get('POMODOIST_ENVIRONMENT') != 'production':
+        raise ValueError('POMODOIST_ENVIRONMENT must be production.')
+    web = https_url(config.get('WEB_APP_URL', ''), 'WEB_APP_URL')
+    if web.path not in ('', '/'):
+        raise ValueError('WEB_APP_URL must be an origin.')
+    registration = https_url(config.get('POMODOIST_REGISTRATION_URL', ''), 'POMODOIST_REGISTRATION_URL')
+    if (registration.netloc != web.netloc or registration.path != '/auth/challenge'):
+        raise ValueError('POMODOIST_REGISTRATION_URL must be /auth/challenge on WEB_APP_URL.')
+    if not config.get('TURNSTILE_SITE_KEY', '').strip():
+        raise ValueError('TURNSTILE_SITE_KEY is required for production account flows.')
+    for field in ('POMODOIST_DEV_UNLOCK', 'POMODOIST_LOCAL_STOREKIT'):
+        if config.get(field, '').lower() not in ('', '0', 'false'):
+            raise ValueError(field + ' must be disabled.')
+    # Existing Apple-platform guard makes this channel account-only on Android.
+    # Do not silently ship Stripe checkout in a Google Play bundle.
+    if config.get('POMODOIST_BILLING_CHANNEL') != 'storekit':
+        raise ValueError('Android uses the guarded storekit channel: account entitlements, no native checkout.')
+    backend = config.get('SUPABASE_URL', '')
+    key = config.get('SUPABASE_ANON_KEY', '')
+    if bool(backend) != bool(key):
+        raise ValueError('SUPABASE_URL and SUPABASE_ANON_KEY must be provided together or both omitted.')
+    if backend:
+        https_url(backend, 'SUPABASE_URL')
+        if not key.startswith('sb_publishable_'):
+            try:
+                payload = key.split('.')[1]
+                claims = json.loads(base64.urlsafe_b64decode(payload + '=' * (-len(payload) % 4)))
+                valid_key = claims.get('role') == 'anon'
+            except (ValueError, IndexError, UnicodeError, AttributeError):
+                valid_key = False
+            if not valid_key:
+                raise ValueError('SUPABASE_ANON_KEY must be a public publishable key or an anon-role JWT.')
+    dsn = config.get('SENTRY_DSN', '')
+    if dsn:
+        url = urlsplit(dsn)
+        if url.scheme != 'https' or not url.hostname or not url.username or url.password or url.query or url.fragment:
+            raise ValueError('SENTRY_DSN must be a public HTTPS DSN, not an auth token.')
+    return config
+
+
+def main():
+    if len(sys.argv) != 2:
+        print('Usage: python3 tool/android/validate_config.py CONFIG.json', file=sys.stderr)
+        return 64
+    try:
+        config = json.loads(Path(sys.argv[1]).read_text(), object_pairs_hook=unique_object)
+        validate(config)
+    except (OSError, ValueError) as error:
+        # Never print configuration values: callers may accidentally include a secret.
+        print('Android production configuration rejected: ' + str(error), file=sys.stderr)
+        return 1
+    print('Android production configuration is valid (public values only).')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tool/android/verify_artifacts.sh
+++ b/tool/android/verify_artifacts.sh
@@ -14,7 +14,7 @@ bundle=build/app/outputs/bundle/release/app-release.aab
 test -s "$apk" && test -s "$bundle"
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
-"$build_tools/apksigner" verify --verbose --print-certs "$apk" > "$work/apk.txt"
+"$build_tools/apksigner" verify --verbose --print-certs-pem "$apk" > "$work/apk.txt"
 if grep -qi 'CN=Android Debug' "$work/apk.txt"; then
   echo 'Refusing an APK signed with an Android Debug certificate.' >&2
   exit 1
@@ -32,9 +32,32 @@ if grep -qi 'unsigned entries' "$work/bundle.txt"; then
   echo 'The AAB contains entries that are not integrity-checked.' >&2
   exit 1
 fi
-keytool -J-Duser.language=en -J-Duser.country=US -printcert -jarfile "$bundle" > "$work/cert.txt"
-apk_sha=$(sed -n 's/^Signer #1 certificate SHA-256 digest: //p' "$work/apk.txt" | tr -d ':[:space:]' | tr '[:lower:]' '[:upper:]')
-bundle_sha=$(sed -n 's/^[[:space:]]*SHA256:[[:space:]]*//p' "$work/cert.txt" | head -n 1 | tr -d ':[:space:]' | tr '[:lower:]' '[:upper:]')
+keytool -J-Duser.language=en -J-Duser.country=US -printcert -rfc -jarfile "$bundle" > "$work/cert.txt"
+# Hash the certificate DER bytes, not version-dependent labels in CLI prose.
+# apksigner may print the same certificate more than once for SDK ranges.
+certificate_sha() {
+  python3 - "$1" <<'PY'
+import base64
+import hashlib
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+blocks = re.findall(r'-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----', text, re.S)
+try:
+    certificates = {base64.b64decode(re.sub(r'\s+', '', block), validate=True) for block in blocks}
+except ValueError:
+    raise SystemExit('Invalid PEM certificate in signing-tool output.')
+if (len(certificates) != 1 or not next(iter(certificates), b'')
+        or len(blocks) != text.count('-----BEGIN CERTIFICATE-----')):
+    raise SystemExit('Expected one distinct signing certificate per artifact; missing certificates and key rotation require review.')
+print(hashlib.sha256(certificates.pop()).hexdigest().upper())
+PY
+}
+apk_sha=$(certificate_sha "$work/apk.txt")
+bundle_sha=$(certificate_sha "$work/cert.txt")
+printf 'APK certificate SHA-256: %s\nAAB certificate SHA-256: %s\n' "$apk_sha" "$bundle_sha"
 if [[ ! "$apk_sha" =~ ^[0-9A-F]{64}$ || "$apk_sha" != "$bundle_sha" ]]; then
   echo 'APK and AAB must use the same signing certificate.' >&2
   exit 1

--- a/tool/android/verify_artifacts.sh
+++ b/tool/android/verify_artifacts.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Verify signatures and identity, not just the presence of output files.
+set -euo pipefail
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cd "$repo_root"
+sdk=${ANDROID_HOME:-${ANDROID_SDK_ROOT:-}}
+if [[ -z "$sdk" || ! -d "$sdk/build-tools" ]]; then
+  echo 'ANDROID_HOME or ANDROID_SDK_ROOT must point to an Android SDK.' >&2
+  exit 64
+fi
+build_tools=$(find "$sdk/build-tools" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -n 1)
+apk=build/app/outputs/flutter-apk/app-release.apk
+bundle=build/app/outputs/bundle/release/app-release.aab
+test -s "$apk" && test -s "$bundle"
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+"$build_tools/apksigner" verify --verbose --print-certs "$apk" > "$work/apk.txt"
+if grep -qi 'CN=Android Debug' "$work/apk.txt"; then
+  echo 'Refusing an APK signed with an Android Debug certificate.' >&2
+  exit 1
+fi
+"$build_tools/aapt" dump badging "$apk" > "$work/badging.txt"
+grep -q "^package: name='com.finchforge.pomodoist' " "$work/badging.txt"
+if grep -q '^application-debuggable' "$work/badging.txt"; then
+  echo 'The release APK must not be debuggable.' >&2
+  exit 1
+fi
+jarsigner -J-Duser.language=en -J-Duser.country=US -verify "$bundle" > "$work/bundle.txt" 2>&1
+# jarsigner can exit successfully for unsigned archives, so inspect its result.
+grep -q 'jar verified\.' "$work/bundle.txt"
+if grep -qi 'unsigned entries' "$work/bundle.txt"; then
+  echo 'The AAB contains entries that are not integrity-checked.' >&2
+  exit 1
+fi
+keytool -J-Duser.language=en -J-Duser.country=US -printcert -jarfile "$bundle" > "$work/cert.txt"
+apk_sha=$(sed -n 's/^Signer #1 certificate SHA-256 digest: //p' "$work/apk.txt" | tr -d ':[:space:]' | tr '[:lower:]' '[:upper:]')
+bundle_sha=$(sed -n 's/^[[:space:]]*SHA256:[[:space:]]*//p' "$work/cert.txt" | head -n 1 | tr -d ':[:space:]' | tr '[:lower:]' '[:upper:]')
+if [[ ! "$apk_sha" =~ ^[0-9A-F]{64}$ || "$apk_sha" != "$bundle_sha" ]]; then
+  echo 'APK and AAB must use the same signing certificate.' >&2
+  exit 1
+fi
+if [[ -n "${ANDROID_SIGNING_CERT_SHA256:-}" ]]; then
+  expected=$(printf '%s' "$ANDROID_SIGNING_CERT_SHA256" | tr -d ':[:space:]' | tr '[:lower:]' '[:upper:]')
+  if [[ "$apk_sha" != "$expected" ]]; then
+    echo 'The release signing certificate does not match ANDROID_SIGNING_CERT_SHA256.' >&2
+    exit 1
+  fi
+fi
+printf 'Verified APK/AAB identity and signatures. Certificate SHA-256: %s\n' "$apk_sha"


### PR DESCRIPTION
## Summary
Refs #50.

`50/android-version` → **main**. The branch was created from main and fast-forwarded to main commit `1ac265a4ec44bbdf90f8cd1b0340541aee6e6573` before the Android implementation was committed. No merge has been performed.

- Replace the template Android identity with `com.finchforge.pomodoist`, relocate MainActivity, and enable Java 17 desugaring and release shrinking.
- Require an external release keystore through environment variables or ignored key.properties. Reject missing credentials, invalid/expired keys and Android debug certificates; never fall back to debug signing.
- Add network/microphone permissions, scheduled-notification and boot receivers, optional microphone hardware, native callback hosts and app_links ownership. Disable release HTTP traffic and auth/database backups/device transfer; allow HTTP only in debug builds.
- Retain a monochrome notification icon. Use exact task/focus reminders only with existing permission and fall back safely when permission is absent or revoked.
- Add public-configuration validation, APK/AAB release commands, cryptographic signature/identity checks, matching and expected certificate verification, checksums, release metadata and separate Dart symbols.
- Add secret-free PR validation with a disposable non-debug key and an Android 15 emulator. Add a separate protected-environment production workflow for reviewed main commits/tags.
- Preserve linked-account entitlements without initializing StoreKit on Android. The guarded `storekit` build channel is intentionally account-only on Android; no Stripe checkout or Google Play Billing is introduced.
- Document setup, signing, CI and the physical-device acceptance matrix in `tool/android/README.md`, linked from `android/README.md`.

## Verification — all four workflows passed at 691b2fa

| Workflow | Result |
| --- | --- |
| [Android validation](https://github.com/Kabanya/Pomodoist/actions/runs/34073557067) | Passed |
| [Validate](https://github.com/Kabanya/Pomodoist/actions/runs/34073557068) | Passed |
| [Chrome extension](https://github.com/Kabanya/Pomodoist/actions/runs/34073557069) | Passed |
| [Self-hosted server](https://github.com/Kabanya/Pomodoist/actions/runs/34073557074) | Passed |

Confirmed:
- [x] `flutter analyze` and the complete `flutter test` suite.
- [x] 30 Python packaging/configuration/verifier tests and six Android Flutter runtime tests, including account entitlements without StoreKit.
- [x] Real Gradle release tasks reject missing signing credentials.
- [x] Actual release APK and AAB compile; APK identity/non-debuggable checks, apksigner/jarsigner integrity checks and matching signing certificates pass.
- [x] Release APK installs and starts on the API 35 x86_64 emulator; background/resume and cold/warm native deep-link process smoke checks pass.
- [x] CI-only APK/AAB artifact uploaded; disposable signing material cleaned up.
- [x] Bash syntax and workflow YAML/Android XML checks.
- [x] Downloaded artifact ZIP matches the GitHub artifact SHA-256. Independent inspection of all **14 arm64-v8a/x86_64 libraries in each artifact** confirms PT_LOAD alignment of at least 16 KB and matching file/virtual-address alignment; all 14 uncompressed APK library entries are also ZIP-aligned to 16 KB. This is a static binary check, **not** a 16 KB runtime/device certification.

### CI-only artifacts
Artifact: `android-validation-NOT-FOR-DISTRIBUTION`, available in the Android workflow run until **2026-09-10**. These use a disposable CI key and local/test configuration, not the production upload key.

| File | Bytes | SHA-256 |
| --- | ---: | --- |
| `app-release.apk` | 86216219 | `4591141efef9502517fc2288d3e0e3f252a2e1eb5d39a4920c2d660cf1295cc8` |
| `app-release.aab` | 80638591 | `e29a7025914bc58edc9d9715f0fc59d9c71c47fc571d0dae8574159fa47f871b` |

## Fixes discovered during CI
Two existing Chrome-extension changes in main blocked repository validation: unpinned Actions and a fake secret fixture caught by the public-boundary scanner. Separate commits pin the same v4 Actions to verified SHAs and assemble the unchanged fake value at runtime. No security checks were disabled.

The Android billing test restores its platform override in `finally`. Certificate comparison now hashes actual PEM/DER certificate bytes instead of parsing SDK-specific digest labels. Missing/multiple distinct certificates are rejected; key rotation or certificate chains require explicit review rather than silently selecting one signer. Real APK/AAB verification now passes.

## Remaining production release gates
- [ ] Configure protected `android-production`, actual upload-key secrets, expected signing SHA-256 and the public Turnstile site key. No production secrets or keystores were read, generated or committed by this change.
- [ ] Run the production workflow with that key/configuration; retain production APK/AAB, checksums and symbols. CI-only artifacts are **not for distribution**.
- [ ] Complete the documented physical phone/tablet acceptance matrix: authentication/CAPTCHA, tasks/Today/Upcoming/Timeline, sync/offline use, voice, reminders/reboot/revocation, focus lifecycle, Calendar/integrations, paid-account access and responsive UI.
- [ ] Perform 16 KB runtime testing and Play internal testing/store-policy review before distribution.

Passing compilation and process-level emulator smoke tests do not establish complete iOS feature parity or physical-device readiness. The remaining release gates are intentionally unchecked; this PR does not automatically close #50.