### PR TITLE
fix: highlight overdue all-day task dates

### DIFF
--- a/lib/app/providers.dart
+++ b/lib/app/providers.dart
@@ -247,7 +247,6 @@ class TaskTimeDisplayModeController extends Notifier<TaskTimeDisplayMode> {
     final prefs = await ref.read(sharedPreferencesProvider.future);
     await prefs?.setString(taskTimeDisplayModePreferenceKey, mode.storageValue);
   }
-
   Future<void> _loadStoredMode() async {
     final prefs = await ref.read(sharedPreferencesProvider.future);
     final mode = TaskTimeDisplayMode.fromStorageValue(
@@ -846,15 +845,9 @@ final taskTimeStateProvider = Provider.autoDispose
 
       final clock = ref.read(clockProvider);
       if (schedule.isAllDay) {
-        return ref.watch(
-          taskTimeTickerProvider.select((ticker) {
-            final localNow = (ticker.value ?? clock.now()).toLocal();
-            final today = DateTime(localNow.year, localNow.month, localNow.day);
-            return schedule.date!.isBefore(today)
-                ? TaskTimeState.overdue
-                : null;
-          }),
-        );
+        final localNow = clock.now().toLocal();
+        final today = DateTime(localNow.year, localNow.month, localNow.day);
+        return schedule.date!.isBefore(today) ? TaskTimeState.overdue : null;
       }
 
       final activeFocusTaskId = ref.watch(

--- a/lib/app/providers.dart
+++ b/lib/app/providers.dart
@@ -838,15 +838,28 @@ final taskTimeTickerProvider = focusTickerProvider;
 final taskTimeStateProvider = Provider.autoDispose
     .family<TaskTimeState?, TaskItem>((ref, task) {
       final schedule = task.schedule;
-      if (schedule == null || !schedule.isTimed || task.isCompleted) {
+      if (schedule == null || task.isCompleted) {
         return task.isCompleted && schedule?.isTimed == true
             ? TaskTimeState.completed
             : null;
       }
+
+      final clock = ref.read(clockProvider);
+      if (schedule.isAllDay) {
+        return ref.watch(
+          taskTimeTickerProvider.select((ticker) {
+            final localNow = (ticker.value ?? clock.now()).toLocal();
+            final today = DateTime(localNow.year, localNow.month, localNow.day);
+            return schedule.date!.isBefore(today)
+                ? TaskTimeState.overdue
+                : null;
+          }),
+        );
+      }
+
       final activeFocusTaskId = ref.watch(
         activeFocusRunProvider.select((run) => run.value?.taskId),
       );
-      final clock = ref.read(clockProvider);
       return ref.watch(
         taskTimeTickerProvider.select(
           (ticker) => taskTimeStateForTask(

--- a/test/task_time_overdue_test.dart
+++ b/test/task_time_overdue_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pomodoist/app/providers.dart';
+import 'package:pomodoist/app/task_time.dart';
+import 'package:pomodoist/core/time/clock.dart';
+import 'package:pomodoist/features/tasks/domain/task_models.dart';
+
+void main() {
+  group('taskTimeStateProvider all-day schedules', () {
+    test('marks a past all-day date as overdue', () {
+      final localNow = DateTime(2026, 9, 7, 12);
+      final now = localNow.toUtc();
+      final container = ProviderContainer(
+        overrides: [
+          activeFocusRunProvider.overrideWith((ref) => Stream.value(null)),
+          clockProvider.overrideWithValue(FixedClock(now)),
+          taskTimeTickerProvider.overrideWith((ref) => Stream.value(now)),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final task = _taskWithSchedule(
+        TaskSchedule.allDay(DateTime(2026, 9, 6)),
+        now: now,
+      );
+
+      expect(
+        container.read(taskTimeStateProvider(task)),
+        TaskTimeState.overdue,
+      );
+    });
+
+    test('does not mark today without a time as overdue', () {
+      final localNow = DateTime(2026, 9, 7, 12);
+      final now = localNow.toUtc();
+      final container = ProviderContainer(
+        overrides: [
+          activeFocusRunProvider.overrideWith((ref) => Stream.value(null)),
+          clockProvider.overrideWithValue(FixedClock(now)),
+          taskTimeTickerProvider.overrideWith((ref) => Stream.value(now)),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final task = _taskWithSchedule(
+        TaskSchedule.allDay(DateTime(2026, 9, 7)),
+        now: now,
+      );
+
+      expect(container.read(taskTimeStateProvider(task)), isNull);
+    });
+  });
+}
+
+TaskItem _taskWithSchedule(TaskSchedule schedule, {required DateTime now}) {
+  return TaskItem(
+    id: 'task',
+    userId: 'user',
+    content: 'Task',
+    projectId: 'project',
+    priority: 4,
+    dueJson: schedule.toJsonString(),
+    status: 'open',
+    completedFocusIntervals: 0,
+    totalFocusSeconds: 0,
+    orderKey: '1',
+    isDeleted: false,
+    createdAt: now,
+    updatedAt: now,
+  );
+}


### PR DESCRIPTION
## Summary
- highlight overdue all-day task dates in red
- keep today's all-day dates unhighlighted
- add regression coverage for both cases

Closes #12