### PR TITLE
feat(updates): automatic Windows and Linux updates (#58)

### DIFF
--- a/.github/workflows/desktop-updates.yml
+++ b/.github/workflows/desktop-updates.yml
@@ -1,0 +1,64 @@
+name: Desktop updater
+
+on:
+  pull_request:
+    paths:
+      - 'lib/**'
+      - 'test/**'
+      - 'tool/test_desktop_update*'
+      - '.github/workflows/desktop-updates.yml'
+      - 'pubspec.*'
+      - '.fvmrc'
+      - 'windows/**'
+      - 'linux/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: desktop-updater-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  updater:
+    name: Updater tests and ${{ matrix.platform }} build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            platform: linux
+          - os: windows-2022
+            platform: windows
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
+        with:
+          flutter-version-file: .fvmrc
+      - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev \
+            libsecret-1-dev libcurl4-openssl-dev libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-base
+      - name: Execute Linux replacement and rollback scenarios
+        if: runner.os == 'Linux'
+        run: python3 -m unittest tool/test_desktop_update_helpers.py
+      - name: Execute Windows installer and rollback scenarios
+        if: runner.os == 'Windows'
+        shell: powershell
+        run: .\tool\test_desktop_update_windows.ps1
+      - run: flutter pub get --enforce-lockfile
+      - name: Test channels, popup, controller and verified downloads
+        run: >-
+          flutter test
+          test/desktop_update_release_test.dart
+          test/desktop_update_controller_test.dart
+          test/desktop_update_widgets_test.dart
+          test/desktop_update_network_test.dart
+      - name: Compile native desktop application
+        run: flutter build ${{ matrix.platform }} --debug

--- a/docs/desktop-updates.md
+++ b/docs/desktop-updates.md
@@ -1,0 +1,99 @@
+# Desktop updates
+
+Pomodoist checks public GitHub releases 10 seconds after startup, every six hours,
+and on resume when its last check was more than an hour ago. Automatic checks run
+in release builds; Settings → About → Updates also works in debug builds. Checks
+never download or execute an installer until the user presses **Update**.
+
+## Channels and assets
+
+Stable is the persistent default. The optional RC switch includes `vX.Y.Z-rc.N`
+alongside stable releases. Drafts, alpha/beta tags, manual Windows preview tags,
+and stable tags marked as prereleases are excluded. Version precedence is SemVer,
+not publication date, string order or Flutter build number. Switching back to
+stable never downgrades an installed newer RC.
+
+All release pages are read, with a bounded request deadline. A release must have
+an exact matching uploaded asset and SHA-256 metadata or checksum sidecar. The
+existing release workflows already publish the required files:
+
+| Process architecture | Windows | Linux |
+| --- | --- | --- |
+| x64 | `Pomodoist-Setup-x64.exe` or existing `Pomodoist-Setup.exe` | `Pomodoist-x86_64.AppImage` |
+| arm64 | `Pomodoist-Setup-arm64.exe` | `Pomodoist-aarch64.AppImage` |
+
+Only x64 assets are currently produced. The updater never mislabels an x64 asset
+as native arm64. An x64 process under Windows ARM emulation requests the x64
+installer. Native arm64 builds need the explicit arm64 release assets above.
+
+Linux in-place updates apply to the official writable AppImage distribution.
+Non-AppImage packages stay under their package manager's control. macOS, iOS,
+Android and web do not instantiate a native updater. Existing releases without
+this code need one initial installation of an updater-enabled build; the feature
+cannot be retroactively added to their running binaries.
+
+## UI and data
+
+The compact bottom-right card shows the version, release notes, **×** and
+**Update**. Tags are persisted before their first notification; closing or
+restarting does not repeat automatic prompts for that tag. Manual checks can
+reopen a dismissed offer. English and Russian copy, light/dark themes, constrained
+windows, progress animation, keyboard-accessible controls and reduced motion are
+supported. Closing a busy popup hides it but does not stop a requested update.
+
+Downloads use a dedicated client without application account credentials. Failed
+automatic checks remain in Settings rather than interrupting work. Manual checks
+show an actionable error. Channel changes and duplicate update requests are
+blocked while an operation is active.
+
+## Installation and recovery
+
+Downloads stream into a private same-volume staging directory. The declared byte
+count and SHA-256 must match; a sidecar must name the exact artifact and agree
+with the GitHub digest when both exist. Only HTTPS GitHub release URLs and its
+allowlisted download CDNs are accepted. Partial files are never executed.
+SHA-256 over GitHub HTTPS detects corruption; it is not independent publisher
+signing. The current Windows installer remains unsigned and Windows policy may
+block it. No signature verification is claimed.
+
+A bundled helper rechecks the hash, takes an installation lock and acknowledges
+readiness before Flutter requests a cancellable, graceful application exit.
+It never kills another running Pomodoist instance to force an update. Cancellation
+or timeout leaves the current executable unchanged.
+
+Linux backs up the original AppImage and atomically renames the verified image
+on the same filesystem. Windows backs up the installation directory, runs the
+existing per-user Inno installer with the **current** `/DIR`, disables forced
+application closure and system reboot, then restarts Pomodoist. It restores the
+old directory if installation or launch fails. Neither helper writes to the
+application database, preferences, account tokens or application-data directories.
+
+The new Flutter window acknowledges startup through a restricted marker. The
+helper restores and relaunches the prior build if no marker arrives. This is a
+window/engine health check, not a guarantee that every future database migration
+is reversible. Failed staging directories retain `error.log`/`startup.log`, the
+installer log and any recovery copy; successful staging is removed by the new
+process. A restored build reports the failed update in Settings.
+
+On abrupt OS power loss, the Linux target is either the old or new complete file;
+Windows relies on Inno Setup's installation recovery and the retained `previous`
+backup. Do not delete a failed staging directory until recovery is confirmed.
+
+## Verification
+
+Run `flutter analyze`, `flutter test` and `flutter build web --debug` for the
+shared code and conditional-import boundary. Focused tests are named
+`test/desktop_update_*_test.dart`.
+
+Run `python3 -m unittest tool/test_desktop_update_helpers.py` on Linux and
+`powershell.exe -NoProfile -ExecutionPolicy Bypass -File tool/test_desktop_update_windows.ps1`
+on Windows. They execute the exact embedded helper scripts against isolated
+fixture executables, including corrupt hashes, cancellation and rollback.
+The `Desktop updater` PR workflow also compiles both native desktop targets.
+It does not publish releases, install into a user's profile or use production secrets.
+
+Before publishing the first updater-enabled release, smoke-test two real release
+builds on Windows 10/11 and an AppImage desktop session: preserve a task, settings
+and login across an update, cancel graceful exit, test a read-only target and
+network failure, and confirm stable/RC behavior and unsigned-installer policy.
+Fixture/CI tests do not substitute for that real-device release acceptance pass.

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -3,6 +3,7 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:pomodoist/l10n/app_localizations.dart';
 
+import '../features/updates/update_widgets.dart';
 import 'app_language.dart';
 import 'platform_quick_add.dart';
 import 'app_theme_mode.dart';
@@ -25,6 +26,9 @@ class PomodoistApp extends ConsumerWidget {
       darkTheme: AppTheme.dark(),
       themeMode: themeMode.themeMode,
       routerConfig: router,
+      builder: (context, child) => DesktopUpdateHost(
+        child: child ?? const SizedBox.shrink(),
+      ),
       locale: language.locale,
       localizationsDelegates: const [
         AppLocalizations.delegate,

--- a/lib/features/settings/presentation/app_info_card.dart
+++ b/lib/features/settings/presentation/app_info_card.dart
@@ -7,6 +7,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import '../../../app/app_l10n.dart';
 import '../../../app/legal_urls.dart';
 import '../../billing/billing.dart';
+import '../../updates/update_widgets.dart';
 
 final appVersionProvider = FutureProvider<String>((ref) async {
   final packageInfo = await PackageInfo.fromPlatform();
@@ -103,6 +104,7 @@ class SettingsAppInfoCard extends ConsumerWidget {
               onTap: () =>
                   unawaited(launchPomodoistExternalUrl(pomodoistSupportUrl)),
             ),
+            const DesktopUpdateSettings(),
           ],
         ),
       ),

--- a/lib/features/updates/github_update_source.dart
+++ b/lib/features/updates/github_update_source.dart
@@ -1,0 +1,61 @@
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+
+import 'update_contracts.dart';
+import 'update_release.dart';
+
+/// Dedicated unauthenticated client: never share account/auth interceptors with
+/// GitHub. All pages are considered because publication order is not SemVer order.
+class GitHubUpdateSource implements UpdateSource {
+  GitHubUpdateSource({Dio? dio}) : _dio = dio ?? Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 15),
+    receiveTimeout: const Duration(seconds: 15),
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'Pomodoist-Desktop-Updater',
+    },
+  ));
+  final Dio _dio;
+  CancelToken? _request;
+
+  @override
+  Future<UpdateOffer?> findUpdate({required UpdateVersion current,
+    required UpdateTarget target, required UpdateChannel channel}) async {
+    final token = CancelToken();
+    _request = token;
+    final deadline = Timer(const Duration(seconds: 45), () => token.cancel('timeout'));
+    final releases = <Object?>[];
+    try {
+      for (var page = 1; page <= 100; page++) {
+        final response = await _dio.get<List<dynamic>>(
+          'https://api.github.com/repos/Kabanya/Pomodoist/releases',
+          queryParameters: {'per_page': 100, 'page': page}, cancelToken: token,
+        );
+        final data = response.data;
+        if (data == null) throw const UpdateFailure('GitHub returned an empty release response.');
+        releases.addAll(data);
+        if (data.length < 100) {
+          return selectUpdate(releases, current: current, target: target, channel: channel);
+        }
+      }
+      throw const UpdateFailure('Too many releases to safely select an update. Try again later.');
+    } on DioException catch (error) {
+      final status = error.response?.statusCode;
+      if (status == 403 || status == 429) {
+        throw const UpdateFailure('GitHub rate limit reached. Please try again later.');
+      }
+      throw const UpdateFailure('Could not check GitHub releases. Check your connection and try again.');
+    } finally {
+      deadline.cancel();
+      if (identical(_request, token)) _request = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _request?.cancel('disposed');
+    _dio.close(force: true);
+  }
+}

--- a/lib/features/updates/update_contracts.dart
+++ b/lib/features/updates/update_contracts.dart
@@ -1,0 +1,39 @@
+import 'update_release.dart';
+
+enum UpdatePhase { idle, checking, available, downloading, verifying, installing, upToDate, failed }
+
+typedef UpdateProgress = void Function(UpdatePhase phase, double? fraction);
+
+class UpdateFailure implements Exception {
+  const UpdateFailure(this.message);
+  final String message;
+  @override
+  String toString() => message;
+}
+
+abstract class UpdateSource {
+  Future<UpdateOffer?> findUpdate({required UpdateVersion current,
+    required UpdateTarget target, required UpdateChannel channel});
+  void dispose();
+}
+
+abstract class UpdateInstaller {
+  UpdateTarget? get target;
+  String? get unavailableReason;
+  Future<String?> acknowledgeStartup();
+  Future<void> install(UpdateOffer offer, UpdateProgress progress);
+  void dispose();
+}
+
+class SavedUpdatePreferences {
+  const SavedUpdatePreferences({this.channel = UpdateChannel.stable,
+    this.seenTags = const {}});
+  final UpdateChannel channel;
+  final Set<String> seenTags;
+}
+
+abstract class UpdatePreferences {
+  Future<SavedUpdatePreferences> load();
+  Future<void> setChannel(UpdateChannel channel);
+  Future<void> markSeen(Set<String> tags);
+}

--- a/lib/features/updates/update_controller.dart
+++ b/lib/features/updates/update_controller.dart
@@ -171,7 +171,9 @@ class DesktopUpdateController extends ChangeNotifier {
   Future<void> update() async {
     final selected = offer;
     if (!enabled || busy || _disposed || selected == null ||
-        (channel == UpdateChannel.stable && !selected.version.isStable)) return;
+        (channel == UpdateChannel.stable && !selected.version.isStable)) {
+      return;
+    }
     phase = UpdatePhase.downloading;
     error = null;
     progress = 0;

--- a/lib/features/updates/update_controller.dart
+++ b/lib/features/updates/update_controller.dart
@@ -1,0 +1,204 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'update_contracts.dart';
+import 'update_release.dart';
+
+class SharedUpdatePreferences implements UpdatePreferences {
+  final _preferences = SharedPreferencesAsync();
+  static const _channelKey = 'desktop.updater.channel';
+  static const _seenKey = 'desktop.updater.seenTags';
+
+  @override
+  Future<SavedUpdatePreferences> load() async => SavedUpdatePreferences(
+    channel: await _preferences.getString(_channelKey) == 'rc'
+        ? UpdateChannel.rc : UpdateChannel.stable,
+    seenTags: (await _preferences.getStringList(_seenKey) ?? const <String>[]).toSet(),
+  );
+  @override
+  Future<void> setChannel(UpdateChannel channel) =>
+      _preferences.setString(_channelKey, channel.name);
+  @override
+  Future<void> markSeen(Set<String> tags) =>
+      _preferences.setStringList(_seenKey, tags.toList()..sort());
+}
+
+class DesktopUpdateController extends ChangeNotifier {
+  DesktopUpdateController({required this.source, required this.installer,
+    required this.preferences, required this.installedVersion,
+    this.automaticChecks = true});
+
+  final UpdateSource source;
+  final UpdateInstaller installer;
+  final UpdatePreferences preferences;
+  final Future<String> Function() installedVersion;
+  final bool automaticChecks;
+  UpdateChannel channel = UpdateChannel.stable;
+  UpdatePhase phase = UpdatePhase.idle;
+  UpdateOffer? offer;
+  String? error;
+  double? progress;
+  bool popupVisible = false;
+  DateTime? lastChecked;
+  final _seen = <String>{};
+  bool _loaded = false;
+  bool _disposed = false;
+  bool _started = false;
+  Future<void>? _loading;
+  Timer? _startupTimer;
+  Timer? _periodicTimer;
+
+  bool get isDesktop => installer.target != null;
+  bool get enabled => isDesktop && installer.unavailableReason == null;
+  bool get busy => const {UpdatePhase.checking, UpdatePhase.downloading,
+    UpdatePhase.verifying, UpdatePhase.installing}.contains(phase);
+
+  Future<void> _ensureLoaded() async {
+    if (_loaded) return;
+    final pending = _loading;
+    if (pending != null) { await pending; return; }
+    final load = () async {
+      final saved = await preferences.load();
+      if (_disposed) return;
+      channel = saved.channel;
+      _seen.addAll(saved.seenTags);
+      _loaded = true;
+    }();
+    _loading = load;
+    try { await load; } finally { _loading = null; }
+  }
+
+  Future<void> start() async {
+    if (_started || _disposed || !isDesktop) return;
+    _started = true;
+    // Acknowledge a rendered application before preferences/network work. No
+    // account or database contents are changed as part of this handshake.
+    try {
+      final warning = await installer.acknowledgeStartup();
+      if (warning != null) { error = warning; phase = UpdatePhase.failed; }
+    } catch (_) { /* Helper will roll back if startup cannot be acknowledged. */ }
+    if (!enabled || _disposed) return;
+    try {
+      await _ensureLoaded();
+    } catch (_) {
+      error = 'Could not load update preferences. Try a manual check.';
+      phase = UpdatePhase.failed;
+    }
+    if (_disposed) return;
+    notifyListeners();
+    if (automaticChecks) {
+      _startupTimer = Timer(const Duration(seconds: 10), () => unawaited(check()));
+      _periodicTimer = Timer.periodic(const Duration(hours: 6), (_) => unawaited(check()));
+    }
+  }
+
+  void onResume() {
+    if (!automaticChecks || !_started || _disposed) return;
+    if (lastChecked == null || DateTime.now().difference(lastChecked!) >= const Duration(hours: 1)) {
+      unawaited(check());
+    }
+  }
+
+  Future<void> check({bool manual = false}) async {
+    if (!enabled || busy || _disposed) return;
+    phase = UpdatePhase.checking;
+    lastChecked = DateTime.now();
+    error = null;
+    notifyListeners();
+    try {
+      await _ensureLoaded();
+      if (_disposed) return;
+      final current = UpdateVersion.parse(await installedVersion());
+      if (_disposed) return;
+      final next = await source.findUpdate(current: current,
+        target: installer.target!, channel: channel);
+      if (_disposed) return;
+      offer = next;
+      lastChecked = DateTime.now();
+      if (next != null && (manual || !_seen.contains(next.tag))) {
+        // Persist before display: dismissal, crashes and restarts cannot turn
+        // the same automatic notification into a repeated interruption.
+        final updated = {..._seen, next.tag};
+        await preferences.markSeen(updated);
+        if (_disposed) return;
+        _seen.add(next.tag);
+        popupVisible = true;
+      } else if (next == null) {
+        popupVisible = false;
+      }
+      phase = next == null ? UpdatePhase.upToDate : UpdatePhase.available;
+    } catch (failure) {
+      if (_disposed) return;
+      phase = UpdatePhase.failed;
+      error = failure.toString();
+      // Automatic network failures stay in Settings, not intrusive popups.
+      if (manual) popupVisible = true;
+    }
+    if (!_disposed) notifyListeners();
+  }
+
+  Future<void> setChannel(UpdateChannel next) async {
+    if (!enabled || busy || _disposed) return;
+    phase = UpdatePhase.checking;
+    notifyListeners();
+    try {
+      await _ensureLoaded();
+      if (_disposed) return;
+      await preferences.setChannel(next);
+      if (_disposed) return;
+      channel = next;
+      offer = null;
+      popupVisible = false;
+      error = null;
+      phase = UpdatePhase.idle;
+      await check(manual: true);
+    } catch (_) {
+      if (_disposed) return;
+      phase = UpdatePhase.failed;
+      error = 'Could not save the update channel. Please try again.';
+      notifyListeners();
+    }
+  }
+
+  void dismiss() {
+    if (_disposed) return;
+    popupVisible = false;
+    notifyListeners();
+  }
+
+  Future<void> update() async {
+    final selected = offer;
+    if (!enabled || busy || _disposed || selected == null ||
+        (channel == UpdateChannel.stable && !selected.version.isStable)) return;
+    phase = UpdatePhase.downloading;
+    error = null;
+    progress = 0;
+    notifyListeners();
+    try {
+      await installer.install(selected, (stage, fraction) {
+        if (_disposed) return;
+        phase = stage;
+        progress = fraction;
+        notifyListeners();
+      });
+    } catch (failure) {
+      if (_disposed) return;
+      error = failure.toString();
+      phase = UpdatePhase.failed;
+      progress = null;
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _startupTimer?.cancel();
+    _periodicTimer?.cancel();
+    source.dispose();
+    installer.dispose();
+    super.dispose();
+  }
+}

--- a/lib/features/updates/update_copy.dart
+++ b/lib/features/updates/update_copy.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+
+import 'update_contracts.dart';
+
+/// Updater copy is kept together because the IO adapter is also compiled on
+/// platforms that do not expose this UI. Fallback follows the app's English UI.
+class UpdateCopy {
+  const UpdateCopy(this.ru);
+  factory UpdateCopy.of(BuildContext context) =>
+      UpdateCopy(Localizations.localeOf(context).languageCode == 'ru');
+  final bool ru;
+  String get title => ru ? 'Обновление Pomodoist' : 'Pomodoist update';
+  String get update => ru ? 'Обновить' : 'Update';
+  String get close => ru ? 'Закрыть' : 'Close';
+  String get check => ru ? 'Проверить обновления' : 'Check for updates';
+  String get settings => ru ? 'Обновления' : 'Updates';
+  String get rc => ru ? 'Получать релиз-кандидаты (RC)' : 'Receive release candidates (RC)';
+  String get stable => ru ? 'Канал: стабильные релизы' : 'Channel: stable releases';
+  String get rcChannel => ru ? 'Канал: стабильные релизы и RC' : 'Channel: stable releases and RC';
+  String get rcHelp => ru ? 'RC могут содержать ошибки. Альфа- и бета-версии исключены.'
+      : 'RC releases may contain bugs. Alpha and beta versions are excluded.';
+  String get restart => ru ? 'Приложение перезапустится. Ваши данные сохранятся.'
+      : 'The app will restart. Your data will be preserved.';
+  String get notes => ru ? 'Все изменения' : 'Release notes';
+  String get unsupported => ru ? 'Автообновление доступно в официальной Linux AppImage. Другие сборки обновляйте через менеджер пакетов.'
+      : 'Automatic updates are available in the official Linux AppImage. Use your package manager for other builds.';
+  String version(String value) => ru ? 'Версия $value' : 'Version $value';
+  String phase(UpdatePhase value) => switch (value) {
+    UpdatePhase.idle => ru ? 'Проверка доступна в любое время.' : 'You can check at any time.',
+    UpdatePhase.checking => ru ? 'Проверяем релизы…' : 'Checking releases…',
+    UpdatePhase.available => ru ? 'Доступна новая версия' : 'A new version is available',
+    UpdatePhase.downloading => ru ? 'Скачиваем обновление…' : 'Downloading update…',
+    UpdatePhase.verifying => ru ? 'Проверяем целостность…' : 'Verifying integrity…',
+    UpdatePhase.installing => ru ? 'Подготавливаем установку и перезапуск…' : 'Preparing installation and restart…',
+    UpdatePhase.upToDate => ru ? 'Установлена последняя подходящая версия.' : 'You have the latest compatible version.',
+    UpdatePhase.failed => ru ? 'Не удалось обновить приложение' : 'The update could not be completed',
+  };
+}

--- a/lib/features/updates/update_downloader_io.dart
+++ b/lib/features/updates/update_downloader_io.dart
@@ -1,0 +1,121 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:dio/dio.dart';
+
+import 'update_contracts.dart';
+import 'update_release.dart';
+
+class UpdateDownloader {
+  UpdateDownloader({Dio? dio}) : _dio = dio ?? Dio(BaseOptions(
+    connectTimeout: const Duration(seconds: 20),
+    receiveTimeout: const Duration(seconds: 30),
+    headers: {'User-Agent': 'Pomodoist-Desktop-Updater'},
+  ));
+  final Dio _dio;
+  final _cancel = CancelToken();
+
+  Future<ResponseBody> _open(UpdateAsset asset, String tag) async {
+    if (!isTrustedUpdateUrl(asset.url, tag, asset.name)) {
+      throw const UpdateFailure('The update URL is not a trusted GitHub release asset.');
+    }
+    var url = asset.url;
+    for (var redirects = 0; redirects < 6; redirects++) {
+      final response = await _dio.get<ResponseBody>(url.toString(),
+        cancelToken: _cancel,
+        options: Options(responseType: ResponseType.stream, followRedirects: false,
+          validateStatus: (status) => status == 200 ||
+              const [301, 302, 303, 307, 308].contains(status)),
+      );
+      final body = response.data;
+      if (body == null) throw const UpdateFailure('Empty update download response.');
+      if (response.statusCode == 200) return body;
+      await body.stream.listen(null).cancel();
+      final location = response.headers.value('location');
+      if (location == null) throw const UpdateFailure('Missing update redirect location.');
+      url = url.resolve(location);
+      const cdnHosts = {'release-assets.githubusercontent.com',
+        'objects.githubusercontent.com', 'github-releases.githubusercontent.com'};
+      if (url.scheme != 'https' || url.port != 443 || url.userInfo.isNotEmpty ||
+          url.hasFragment || !(cdnHosts.contains(url.host) ||
+            isTrustedUpdateUrl(url, tag, asset.name))) {
+        throw const UpdateFailure('Unsafe update download redirect.');
+      }
+    }
+    throw const UpdateFailure('Too many update download redirects.');
+  }
+
+  Future<String> _checksum(UpdateOffer offer) async {
+    var expected = offer.asset.sha256;
+    final sidecar = offer.checksum;
+    if (sidecar != null) {
+      final response = await _open(sidecar, offer.tag);
+      final bytes = <int>[];
+      await for (final chunk in response.stream.timeout(const Duration(seconds: 30))) {
+        bytes.addAll(chunk);
+        if (bytes.length > 4096) throw const UpdateFailure('Checksum file is too large.');
+      }
+      if (bytes.length != sidecar.size) throw const UpdateFailure('Incomplete checksum download.');
+      final checksum = parseUpdateChecksum(utf8.decode(bytes), offer.asset.name);
+      if (expected != null && expected != checksum) {
+        throw const UpdateFailure('The release checksum and GitHub digest disagree.');
+      }
+      expected = checksum;
+    }
+    if (expected == null || !RegExp(r'^[a-f0-9]{64}$').hasMatch(expected)) {
+      throw const UpdateFailure('The release does not provide a valid SHA-256 checksum.');
+    }
+    return expected;
+  }
+
+  /// Streams to disk, checks the exact byte count, then hashes from disk. Only a
+  /// verified file is promoted from .part to the executable installer filename.
+  Future<String> download(UpdateOffer offer, File destination, UpdateProgress progress) async {
+    final partial = File('${destination.path}.part');
+    final deadline = Timer(const Duration(minutes: 20), () => _cancel.cancel('timeout'));
+    try {
+      if (offer.asset.size <= 0 || offer.asset.size > 512 * 1024 * 1024) {
+        throw const UpdateFailure('Unsupported update artifact size.');
+      }
+      final expected = await _checksum(offer);
+      final response = await _open(offer.asset, offer.tag);
+      final sink = partial.openWrite();
+      var received = 0;
+      final throttle = Stopwatch()..start();
+      try {
+        await sink.addStream(response.stream.timeout(const Duration(seconds: 30)).map((chunk) {
+          received += chunk.length;
+          if (received > offer.asset.size) {
+            throw const UpdateFailure('The update is larger than its declared size.');
+          }
+          if (throttle.elapsedMilliseconds >= 100 || received == offer.asset.size) {
+            progress(UpdatePhase.downloading, received / offer.asset.size);
+            throttle.reset();
+          }
+          return chunk;
+        }));
+        await sink.flush();
+      } finally {
+        await sink.close();
+      }
+      if (received != offer.asset.size) throw const UpdateFailure('The update download was interrupted.');
+      progress(UpdatePhase.verifying, null);
+      final actual = (await sha256.bind(partial.openRead()).first).toString();
+      if (actual != expected) throw const UpdateFailure('Update integrity check failed. Nothing was installed.');
+      await partial.rename(destination.path);
+      return expected;
+    } on DioException {
+      throw const UpdateFailure('Update download failed. Check your connection and retry.');
+    } finally {
+      deadline.cancel();
+      if (await partial.exists()) await partial.delete();
+    }
+  }
+
+  void dispose() {
+    _cancel.cancel('disposed');
+    _dio.close(force: true);
+  }
+}

--- a/lib/features/updates/update_downloader_io.dart
+++ b/lib/features/updates/update_downloader_io.dart
@@ -97,9 +97,13 @@ class UpdateDownloader {
           return chunk;
         }));
         await sink.flush();
-      } finally {
-        await sink.close();
+      } catch (_) {
+        // addStream can close its file sink on a source error. A second close
+        // must not replace the original integrity/network failure.
+        try { await sink.close(); } catch (_) { /* Preserve the source error. */ }
+        rethrow;
       }
+      await sink.close();
       if (received != offer.asset.size) throw const UpdateFailure('The update download was interrupted.');
       progress(UpdatePhase.verifying, null);
       final actual = (await sha256.bind(partial.openRead()).first).toString();

--- a/lib/features/updates/update_install_scripts.dart
+++ b/lib/features/updates/update_install_scripts.dart
@@ -1,0 +1,198 @@
+// Bundled helpers, not downloaded code. Arguments are passed as an argv vector.
+// Keep these scripts independently executable: tool tests run these exact bytes.
+const linuxUpdateScript = r'''
+#!/bin/sh
+set -eu
+umask 077
+[ "$#" -eq 4 ] || exit 64
+parent=$1
+target=$2
+payload=$3
+expected=$4
+case "$parent" in ''|*[!0-9]*|0|1) exit 64 ;; esac
+case "$target" in /*) ;; *) exit 64 ;; esac
+[ -f "$target" ] && [ ! -L "$target" ] || exit 65
+[ -f "$payload" ] && [ ! -L "$payload" ] || exit 65
+stage=$(CDPATH= cd -- "$(dirname -- "$payload")" && pwd -P)
+appdir=$(CDPATH= cd -- "$(dirname -- "$target")" && pwd -P)
+case "$stage" in "$appdir"/.pomodoist-update-*) ;; *) exit 65 ;; esac
+[ "$(dirname -- "$stage")" = "$appdir" ] || exit 65
+[ "${#expected}" -eq 64 ] || exit 65
+case "$expected" in *[!a-fA-F0-9]*) exit 65 ;; esac
+actual=$(sha256sum < "$payload")
+actual=${actual%% *}
+[ "$actual" = "$expected" ] || exit 66
+# Never inherit paths into the old AppImage's soon-to-be-unmounted AppDir.
+unset APPIMAGE APPDIR ARGV0 OWD LD_LIBRARY_PATH LD_PRELOAD
+unset GSETTINGS_SCHEMA_DIR GIO_EXTRA_MODULES GDK_PIXBUF_MODULE_FILE GTK_PATH
+lock="$target.update-lock"
+if ! mkdir -- "$lock" 2>/dev/null; then
+  # Recover only our own stale lock, not an arbitrary directory or symlink.
+  [ -d "$lock" ] && [ ! -L "$lock" ] && [ -f "$lock/pid" ] || exit 73
+  owner=$(cat -- "$lock/pid")
+  case "$owner" in ''|*[!0-9]*|0|1) exit 73 ;; esac
+  kill -0 "$owner" 2>/dev/null && exit 73
+  rm -- "$lock/pid"
+  rmdir -- "$lock"
+  mkdir -- "$lock"
+fi
+printf '%s\n' "$$" > "$lock/pid"
+backup="$stage/previous.AppImage"
+replaced=false
+finished=false
+child=''
+cleanup() {
+  code=$?
+  trap - EXIT HUP INT TERM
+  if [ "$finished" != true ]; then
+    printf 'failed\n' > "$stage/result"
+    if [ "$replaced" = true ]; then
+      if [ -n "$child" ]; then
+        kill "$child" 2>/dev/null || true
+        wait "$child" 2>/dev/null || true
+      fi
+      # Rename back on the same filesystem. Never remove the target first.
+      if mv -f -- "$backup" "$target"; then
+        POMODOIST_UPDATE_ERROR=1 "$target" >/dev/null 2>&1 &
+      fi
+    fi
+  fi
+  rm -f -- "$lock/pid"
+  rmdir -- "$lock" 2>/dev/null || true
+  if [ "$finished" = true ]; then printf 'success\n' > "$stage/result"; fi
+  exit "$code"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+printf 'ready\n' > "$stage/ready"
+tries=0
+while kill -0 "$parent" 2>/dev/null; do
+  [ ! -e "$stage/cancel" ] || exit 75
+  tries=$((tries + 1))
+  [ "$tries" -lt 120 ] || exit 75
+  sleep 1
+done
+[ ! -e "$stage/cancel" ] || exit 75
+# Check again after the old process exits, before touching its executable.
+actual=$(sha256sum < "$payload")
+[ "${actual%% *}" = "$expected" ] || exit 66
+chmod 755 -- "$payload"
+# A hardlink is fast and survives an interruption; copy on filesystems without it.
+ln -- "$target" "$backup" 2>/dev/null || cp -p -- "$target" "$backup"
+sync
+mv -f -- "$payload" "$target"
+replaced=true
+sync
+POMODOIST_UPDATE_READY_FILE="$stage/started" "$target" > "$stage/startup.log" 2>&1 &
+child=$!
+tries=0
+while [ ! -f "$stage/started" ]; do
+  kill -0 "$child" 2>/dev/null || exit 70
+  tries=$((tries + 1))
+  [ "$tries" -lt 60 ] || exit 70
+  sleep 1
+done
+finished=true
+rm -f -- "$backup" || true
+''';
+
+const windowsUpdateScript = r'''
+param(
+  [Parameter(Mandatory=$true)][int]$ParentProcessId,
+  [Parameter(Mandatory=$true)][string]$ApplicationPath,
+  [Parameter(Mandatory=$true)][string]$InstallerPath,
+  [Parameter(Mandatory=$true)][ValidatePattern('^[a-fA-F0-9]{64}$')][string]$Sha256
+)
+$ErrorActionPreference = 'Stop'
+$stage = Split-Path -Parent $InstallerPath
+$installDir = Split-Path -Parent $ApplicationPath
+$backup = Join-Path $stage 'previous'
+$lock = $null
+$changed = $false
+$started = $null
+$oldExited = $false
+$finished = $false
+try {
+  if ($ParentProcessId -le 1 -or
+      -not [IO.Path]::IsPathRooted($ApplicationPath) -or
+      -not [IO.Path]::IsPathRooted($InstallerPath) -or
+      [IO.Path]::GetFileName($ApplicationPath) -ine 'pomodoist.exe' -or
+      -not (Test-Path -LiteralPath $ApplicationPath -PathType Leaf) -or
+      -not (Test-Path -LiteralPath $InstallerPath -PathType Leaf)) {
+    throw 'Invalid update paths or process.'
+  }
+  foreach ($path in @($installDir, $ApplicationPath, $InstallerPath, $stage)) {
+    if ((Get-Item -LiteralPath $path).Attributes -band [IO.FileAttributes]::ReparsePoint) {
+      throw 'Updates through reparse points are not supported.'
+    }
+  }
+  if ((Get-FileHash -LiteralPath $InstallerPath -Algorithm SHA256).Hash -ine $Sha256) {
+    throw 'Installer SHA-256 mismatch.'
+  }
+  $lock = [IO.File]::Open($installDir + '.update-lock',
+    [IO.FileMode]::OpenOrCreate, [IO.FileAccess]::ReadWrite, [IO.FileShare]::None)
+  'ready' | Set-Content -LiteralPath (Join-Path $stage 'ready')
+  $deadline = [DateTime]::UtcNow.AddSeconds(120)
+  while (Get-Process -Id $ParentProcessId -ErrorAction SilentlyContinue) {
+    if ((Test-Path -LiteralPath (Join-Path $stage 'cancel')) -or
+        [DateTime]::UtcNow -gt $deadline) { throw 'Application exit was cancelled.' }
+    Start-Sleep -Milliseconds 200
+  }
+  if (Test-Path -LiteralPath (Join-Path $stage 'cancel')) {
+    throw 'Application exit was cancelled.'
+  }
+  $oldExited = $true
+  if ((Get-FileHash -LiteralPath $InstallerPath -Algorithm SHA256).Hash -ine $Sha256) {
+    throw 'Installer changed after verification.'
+  }
+  # Never force-close another application instance or overwrite locked files.
+  $others = @(Get-Process -Name 'pomodoist' -ErrorAction SilentlyContinue |
+    Where-Object { $_.Path -ieq $ApplicationPath })
+  if ($others.Count -gt 0) { throw 'Another Pomodoist instance is still running.' }
+  Copy-Item -LiteralPath $installDir -Destination $backup -Recurse
+  $changed = $true
+  $arguments = @('/SILENT', '/SUPPRESSMSGBOXES', '/SP-', '/NORESTART',
+    '/NOCLOSEAPPLICATIONS', '/NORESTARTAPPLICATIONS', '/RESTARTEXITCODE=3010',
+    ('/DIR="' + $installDir + '"'), ('/LOG="' + (Join-Path $stage 'install.log') + '"'))
+  $installer = Start-Process -FilePath $InstallerPath -ArgumentList $arguments -Wait -PassThru
+  if ($installer.ExitCode -ne 0) {
+    throw ('Installer failed or requires a reboot: ' + $installer.ExitCode)
+  }
+  $env:POMODOIST_UPDATE_READY_FILE = Join-Path $stage 'started'
+  $started = Start-Process -FilePath $ApplicationPath -WorkingDirectory $installDir -PassThru
+  Remove-Item Env:POMODOIST_UPDATE_READY_FILE
+  $deadline = [DateTime]::UtcNow.AddSeconds(60)
+  while (-not (Test-Path -LiteralPath (Join-Path $stage 'started'))) {
+    if ($started.HasExited -or [DateTime]::UtcNow -gt $deadline) {
+      throw 'The updated application did not start.'
+    }
+    Start-Sleep -Milliseconds 200
+  }
+  # Cleanup failure must not roll back an application that started successfully.
+  Remove-Item -LiteralPath $backup -Recurse -Force -ErrorAction SilentlyContinue
+  $finished = $true
+} catch {
+  $_ | Out-String | Set-Content -LiteralPath (Join-Path $stage 'error.log')
+  'failed' | Set-Content -LiteralPath (Join-Path $stage 'result')
+  if ($changed) {
+    if ($null -ne $started -and -not $started.HasExited) {
+      Stop-Process -Id $started.Id -Force -ErrorAction SilentlyContinue
+      $started.WaitForExit()
+    }
+    # The old binary and all bundled libraries were copied before installation.
+    # Keep both copies on restore failure for recovery; never delete the backup.
+    $failed = Join-Path $stage 'failed-install'
+    Move-Item -LiteralPath $installDir -Destination $failed
+    Move-Item -LiteralPath $backup -Destination $installDir
+  }
+  if ($oldExited -and (Test-Path -LiteralPath $ApplicationPath)) {
+    $env:POMODOIST_UPDATE_ERROR = '1'
+    Remove-Item Env:POMODOIST_UPDATE_READY_FILE -ErrorAction SilentlyContinue
+    Start-Process -FilePath $ApplicationPath -WorkingDirectory $installDir
+  }
+  exit 1
+} finally {
+  if ($null -ne $lock) { $lock.Dispose() }
+  if ($finished) { 'success' | Set-Content -LiteralPath (Join-Path $stage 'result') }
+}
+''';

--- a/lib/features/updates/update_installer.dart
+++ b/lib/features/updates/update_installer.dart
@@ -1,0 +1,2 @@
+export 'update_installer_stub.dart'
+    if (dart.library.io) 'update_installer_io.dart';

--- a/lib/features/updates/update_installer_io.dart
+++ b/lib/features/updates/update_installer_io.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:ui' show AppExitResponse, AppExitType;
+
+import 'package:flutter/services.dart';
+import 'package:path/path.dart' as p;
+
+import 'update_contracts.dart';
+import 'update_downloader_io.dart';
+import 'update_install_scripts.dart';
+import 'update_release.dart';
+
+UpdateInstaller createUpdateInstaller() => NativeUpdateInstaller();
+
+class NativeUpdateInstaller implements UpdateInstaller {
+  bool _disposed = false;
+  bool _exitRequested = false;
+  UpdateDownloader? _downloader;
+  Directory? _helperStage;
+
+  @override
+  UpdateTarget? get target => switch (Abi.current()) {
+    Abi.windowsX64 => const UpdateTarget(UpdateOS.windows, UpdateArch.x64),
+    Abi.windowsArm64 => const UpdateTarget(UpdateOS.windows, UpdateArch.arm64),
+    Abi.linuxX64 => const UpdateTarget(UpdateOS.linux, UpdateArch.x64),
+    Abi.linuxArm64 => const UpdateTarget(UpdateOS.linux, UpdateArch.arm64),
+    _ => null,
+  };
+
+  @override
+  String? get unavailableReason => Platform.isLinux &&
+      (Platform.environment['APPIMAGE'] ?? '').isEmpty
+      ? 'Automatic updates require the official Linux AppImage. Use your package manager for other distributions.'
+      : null;
+
+  @override
+  Future<String?> acknowledgeStartup() async {
+    final warning = Platform.environment['POMODOIST_UPDATE_ERROR'] == '1'
+        ? 'The previous update failed. Your previous version was restored. Check for updates to retry.' : null;
+    final marker = Platform.environment['POMODOIST_UPDATE_READY_FILE'];
+    if (marker == null || !p.isAbsolute(marker) || p.basename(marker) != 'started') return warning;
+    final stage = Directory(p.dirname(marker));
+    if (!p.basename(stage.path).startsWith('.pomodoist-update-') || !await stage.exists()) return warning;
+    // Do not let an arbitrary launch environment redirect the health marker.
+    if (await stage.resolveSymbolicLinks() != stage.absolute.path) return warning;
+    await File(marker).writeAsString('started\n', flush: true);
+    unawaited(_cleanSuccessfulStage(stage));
+    return warning;
+  }
+
+  Future<void> _cleanSuccessfulStage(Directory stage) async {
+    // The helper owns the staging directory until it has released its lock and
+    // completed backup cleanup. Failed updates retain logs/backups for recovery.
+    try {
+      for (var attempt = 0; attempt < 90 && !_disposed; attempt++) {
+        await Future<void>.delayed(const Duration(seconds: 1));
+        final result = File(p.join(stage.path, 'result'));
+        if (!await result.exists()) continue;
+        if ((await result.readAsString()).trim() == 'success') {
+          await Future<void>.delayed(const Duration(seconds: 2));
+          await stage.delete(recursive: true);
+        }
+        return;
+      }
+    } catch (_) { /* Cleanup must never interrupt normal application startup. */ }
+  }
+
+  Map<String, String> _helperEnvironment() {
+    final environment = Map<String, String>.from(Platform.environment);
+    for (final name in const ['APPIMAGE', 'APPDIR', 'ARGV0', 'OWD',
+      'LD_LIBRARY_PATH', 'LD_PRELOAD', 'GSETTINGS_SCHEMA_DIR', 'GIO_EXTRA_MODULES',
+      'GDK_PIXBUF_MODULE_FILE', 'GTK_PATH', 'POMODOIST_UPDATE_READY_FILE',
+      'POMODOIST_UPDATE_ERROR']) {
+      environment.remove(name);
+    }
+    return environment;
+  }
+
+  @override
+  Future<void> install(UpdateOffer offer, UpdateProgress progress) async {
+    final platform = target;
+    if (_disposed || platform == null || unavailableReason != null) {
+      throw UpdateFailure(unavailableReason ?? 'Desktop updating is unavailable.');
+    }
+    if (!platform.artifactNames.contains(offer.asset.name)) {
+      throw const UpdateFailure('The update does not match this platform and architecture.');
+    }
+    final executable = platform.os == UpdateOS.linux
+        ? await File(Platform.environment['APPIMAGE']!).resolveSymbolicLinks()
+        : Platform.resolvedExecutable;
+    if (platform.os == UpdateOS.windows && p.basename(executable).toLowerCase() != 'pomodoist.exe') {
+      throw const UpdateFailure('Use an installed Pomodoist desktop build to update.');
+    }
+    // Sibling staging keeps Linux rename atomic and Windows rollback on the same
+    // volume. Creating it also checks permissions before downloading anything.
+    final parent = Directory(platform.os == UpdateOS.windows
+        ? p.dirname(p.dirname(executable)) : p.dirname(executable));
+    Directory? stage;
+    var helperStarted = false;
+    final downloader = UpdateDownloader();
+    _downloader = downloader;
+    try {
+      stage = await parent.createTemp('.pomodoist-update-');
+      if (platform.os == UpdateOS.linux) {
+        final chmod = await Process.run('/bin/chmod', ['700', stage.path]);
+        if (chmod.exitCode != 0) throw const UpdateFailure('Could not secure update staging directory.');
+      }
+      final payload = File(p.join(stage.path, offer.asset.name));
+      final hash = await downloader.download(offer, payload, progress);
+      if (_disposed) throw const UpdateFailure('Update cancelled.');
+      progress(UpdatePhase.installing, null);
+      final windows = platform.os == UpdateOS.windows;
+      final script = File(p.join(stage.path, windows ? 'install.ps1' : 'install.sh'));
+      await script.writeAsString(windows ? windowsUpdateScript : linuxUpdateScript, flush: true);
+      final command = windows
+          ? p.join(Platform.environment['SystemRoot'] ?? r'C:\Windows',
+              'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+          : '/bin/sh';
+      final arguments = windows
+          ? ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass',
+              '-WindowStyle', 'Hidden', '-File', script.path,
+              '-ParentProcessId', '$pid', '-ApplicationPath', executable,
+              '-InstallerPath', payload.path, '-Sha256', hash]
+          : [script.path, '$pid', executable, payload.path, hash];
+      await Process.start(command, arguments, mode: ProcessStartMode.detached,
+        workingDirectory: stage.path, environment: _helperEnvironment(),
+        includeParentEnvironment: false);
+      helperStarted = true;
+      _helperStage = stage;
+      final ready = File(p.join(stage.path, 'ready'));
+      for (var attempt = 0; attempt < 150 && !await ready.exists(); attempt++) {
+        if (_disposed || await File(p.join(stage.path, 'result')).exists()) break;
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }
+      if (_disposed || !await ready.exists()) {
+        throw const UpdateFailure('The installer could not prepare the update. The application was not changed.');
+      }
+      _exitRequested = true;
+      final response = await ServicesBinding.instance.exitApplication(AppExitType.cancelable);
+      if (response == AppExitResponse.cancel) {
+        _exitRequested = false;
+        throw const UpdateFailure('Restart cancelled. Your current application is still running.');
+      }
+    } on FileSystemException {
+      _exitRequested = false;
+      throw const UpdateFailure('The update location is not writable or has insufficient disk space.');
+    } catch (_) {
+      _exitRequested = false;
+      rethrow;
+    } finally {
+      downloader.dispose();
+      _downloader = null;
+      // Normal successful handoff exits the process and never reaches here.
+      if (stage != null && !_exitRequested) {
+        if (helperStarted) {
+          try { await File(p.join(stage.path, 'cancel')).writeAsString('cancel\n', flush: true); }
+          catch (_) { /* The helper also times out without a graceful exit. */ }
+        } else {
+          try { await stage.delete(recursive: true); } catch (_) { /* Best effort. */ }
+        }
+      }
+      _helperStage = null;
+    }
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    _downloader?.dispose();
+    final stage = _helperStage;
+    if (stage != null && !_exitRequested) {
+      try { File(p.join(stage.path, 'cancel')).writeAsStringSync('cancel\n', flush: true); }
+      catch (_) { /* No executable is replaced while the parent remains alive. */ }
+    }
+  }
+}

--- a/lib/features/updates/update_installer_stub.dart
+++ b/lib/features/updates/update_installer_stub.dart
@@ -1,0 +1,18 @@
+import 'update_contracts.dart';
+import 'update_release.dart';
+
+UpdateInstaller createUpdateInstaller() => _UnsupportedUpdateInstaller();
+
+class _UnsupportedUpdateInstaller implements UpdateInstaller {
+  @override
+  UpdateTarget? get target => null;
+  @override
+  String? get unavailableReason => null;
+  @override
+  Future<String?> acknowledgeStartup() async => null;
+  @override
+  Future<void> install(UpdateOffer offer, UpdateProgress progress) async =>
+      throw const UpdateFailure('Desktop updates are not supported on this platform.');
+  @override
+  void dispose() {}
+}

--- a/lib/features/updates/update_providers.dart
+++ b/lib/features/updates/update_providers.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import 'github_update_source.dart';
+import 'update_controller.dart';
+import 'update_installer.dart';
+
+final desktopUpdateControllerProvider = Provider<DesktopUpdateController>((ref) {
+  final controller = DesktopUpdateController(
+    source: GitHubUpdateSource(),
+    installer: createUpdateInstaller(),
+    preferences: SharedUpdatePreferences(),
+    installedVersion: () async => (await PackageInfo.fromPlatform()).version,
+    // Development/test runs never contact GitHub automatically. A real release
+    // checks after startup and on a six-hour cadence; manual checks remain usable.
+    automaticChecks: kReleaseMode,
+  );
+  ref.onDispose(controller.dispose);
+  return controller;
+});

--- a/lib/features/updates/update_release.dart
+++ b/lib/features/updates/update_release.dart
@@ -1,0 +1,167 @@
+enum UpdateChannel { stable, rc }
+enum UpdateOS { windows, linux }
+enum UpdateArch { x64, arm64 }
+
+class UpdateTarget {
+  const UpdateTarget(this.os, this.arch);
+  final UpdateOS os;
+  final UpdateArch arch;
+
+  List<String> get artifactNames => switch ((os, arch)) {
+    (UpdateOS.windows, UpdateArch.x64) => const [
+      'Pomodoist-Setup-x64.exe', 'Pomodoist-Setup.exe',
+    ],
+    (UpdateOS.windows, UpdateArch.arm64) => const ['Pomodoist-Setup-arm64.exe'],
+    (UpdateOS.linux, UpdateArch.x64) => const ['Pomodoist-x86_64.AppImage'],
+    (UpdateOS.linux, UpdateArch.arm64) => const ['Pomodoist-aarch64.AppImage'],
+  };
+}
+
+/// SemVer precedence deliberately ignores build metadata, including Flutter's
+/// build number. Numeric identifiers use BigInt to avoid overflow/lexical order.
+class UpdateVersion implements Comparable<UpdateVersion> {
+  UpdateVersion._(this.text, this.numbers, this.prerelease);
+  final String text;
+  final List<BigInt> numbers;
+  final List<String> prerelease;
+  bool get isStable => prerelease.isEmpty;
+  bool get isRc => prerelease.length == 2 && prerelease.first == 'rc' &&
+      RegExp(r'^\d+$').hasMatch(prerelease.last);
+
+  static UpdateVersion parse(String text) => tryParse(text) ??
+      (throw FormatException('Invalid semantic version: $text'));
+
+  static UpdateVersion? tryParse(String text) {
+    if (text.length > 256) return null;
+    final match = RegExp(
+      r'^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)'
+      r'(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?'
+      r'(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$',
+    ).firstMatch(text);
+    if (match == null) return null;
+    final pre = match.group(4)?.split('.') ?? const <String>[];
+    for (final part in pre) {
+      if (RegExp(r'^\d+$').hasMatch(part) && part.length > 1 && part.startsWith('0')) {
+        return null;
+      }
+    }
+    return UpdateVersion._(text.replaceFirst(RegExp(r'^v'), ''),
+      [for (var i = 1; i <= 3; i++) BigInt.parse(match.group(i)!)], pre);
+  }
+
+  @override
+  int compareTo(UpdateVersion other) {
+    for (var i = 0; i < 3; i++) {
+      final comparison = numbers[i].compareTo(other.numbers[i]);
+      if (comparison != 0) return comparison;
+    }
+    if (isStable || other.isStable) {
+      return isStable == other.isStable ? 0 : (isStable ? 1 : -1);
+    }
+    for (var i = 0; i < prerelease.length && i < other.prerelease.length; i++) {
+      final left = prerelease[i];
+      final right = other.prerelease[i];
+      final leftNumber = RegExp(r'^\d+$').hasMatch(left) ? BigInt.parse(left) : null;
+      final rightNumber = RegExp(r'^\d+$').hasMatch(right) ? BigInt.parse(right) : null;
+      final comparison = leftNumber != null && rightNumber != null
+          ? leftNumber.compareTo(rightNumber)
+          : leftNumber != null ? -1
+          : rightNumber != null ? 1 : left.compareTo(right);
+      if (comparison != 0) return comparison;
+    }
+    return prerelease.length.compareTo(other.prerelease.length);
+  }
+}
+
+class UpdateAsset {
+  const UpdateAsset({required this.name, required this.url, required this.size,
+    this.sha256});
+  final String name;
+  final Uri url;
+  final int size;
+  final String? sha256;
+}
+
+class UpdateOffer {
+  const UpdateOffer({required this.tag, required this.version, required this.notes,
+    required this.asset, this.checksum});
+  final String tag;
+  final UpdateVersion version;
+  final String notes;
+  final UpdateAsset asset;
+  final UpdateAsset? checksum;
+  Uri get releaseUrl => Uri.https('github.com', '/Kabanya/Pomodoist/releases/tag/$tag');
+}
+
+bool isTrustedUpdateUrl(Uri uri, String tag, String name) {
+  final parts = uri.pathSegments;
+  return uri.scheme == 'https' && uri.host == 'github.com' && uri.port == 443 &&
+      uri.userInfo.isEmpty && !uri.hasQuery && !uri.hasFragment &&
+      parts.length == 6 && parts[0] == 'Kabanya' && parts[1] == 'Pomodoist' &&
+      parts[2] == 'releases' && parts[3] == 'download' &&
+      parts[4] == tag && parts[5] == name;
+}
+
+UpdateAsset? _asset(Object? raw, String tag) {
+  if (raw is! Map) return null;
+  final name = raw['name'];
+  final size = raw['size'];
+  final url = raw['browser_download_url'];
+  if (name is! String || size is! int || size <= 0 ||
+      size > 512 * 1024 * 1024 || url is! String || raw['state'] != 'uploaded') {
+    return null;
+  }
+  final uri = Uri.tryParse(url);
+  if (uri == null || !isTrustedUpdateUrl(uri, tag, name)) return null;
+  final digest = raw['digest'];
+  final hash = digest is String && RegExp(r'^sha256:[a-fA-F0-9]{64}$').hasMatch(digest)
+      ? digest.substring(7).toLowerCase() : null;
+  return UpdateAsset(name: name, url: uri, size: size, sha256: hash);
+}
+
+UpdateOffer? selectUpdate(List<Object?> releases, {required UpdateVersion current,
+  required UpdateTarget target, required UpdateChannel channel}) {
+  UpdateOffer? best;
+  for (final raw in releases) {
+    if (raw is! Map || raw['draft'] != false || raw['tag_name'] is! String) continue;
+    final tag = raw['tag_name'] as String;
+    final version = UpdateVersion.tryParse(tag);
+    if (version == null || version.compareTo(current) <= 0) continue;
+    final stable = version.isStable && raw['prerelease'] == false;
+    if (!stable && !(channel == UpdateChannel.rc && version.isRc)) continue;
+    if (best != null && version.compareTo(best.version) <= 0) continue;
+    final assetsRaw = raw['assets'];
+    if (assetsRaw is! List) continue;
+    final assets = assetsRaw.map((a) => _asset(a, tag)).whereType<UpdateAsset>().toList();
+    for (final name in target.artifactNames) {
+      final matches = assets.where((a) => a.name == name).toList();
+      if (matches.length != 1) continue;
+      final artifact = matches.single;
+      final checksums = assets.where((a) => a.name == '$name.sha256' && a.size <= 4096).toList();
+      final checksum = checksums.length == 1 ? checksums.single : null;
+      if (artifact.sha256 == null && checksum == null) continue;
+      final notes = raw['body'] is String ? raw['body'] as String : '';
+      best = UpdateOffer(tag: tag, version: version,
+        notes: notes.length > 8000 ? '${notes.substring(0, 8000)}…' : notes,
+        asset: artifact, checksum: checksum);
+      break;
+    }
+  }
+  return best;
+}
+
+String parseUpdateChecksum(String text, String artifactName) {
+  if (text.length > 4096) throw const FormatException('Checksum file is too large.');
+  String? result;
+  for (final line in text.split(RegExp(r'\r?\n'))) {
+    final match = RegExp(r'^([a-fA-F0-9]{64})[ \t]+\*?(.+)$').firstMatch(line.trim());
+    if (match != null && match.group(2) == artifactName) {
+      final hash = match.group(1)!.toLowerCase();
+      if (result != null && result != hash) {
+        throw const FormatException('Conflicting SHA-256 entries.');
+      }
+      result = hash;
+    }
+  }
+  return result ?? (throw const FormatException('No SHA-256 for the exact update artifact.'));
+}

--- a/lib/features/updates/update_widgets.dart
+++ b/lib/features/updates/update_widgets.dart
@@ -1,0 +1,200 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import 'update_contracts.dart';
+import 'update_controller.dart';
+import 'update_copy.dart';
+import 'update_providers.dart';
+import 'update_release.dart';
+
+class DesktopUpdateHost extends ConsumerStatefulWidget {
+  const DesktopUpdateHost({required this.child, super.key});
+  final Widget child;
+  @override
+  ConsumerState<DesktopUpdateHost> createState() => _DesktopUpdateHostState();
+}
+
+class _DesktopUpdateHostState extends ConsumerState<DesktopUpdateHost>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) unawaited(ref.read(desktopUpdateControllerProvider).start());
+    });
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      ref.read(desktopUpdateControllerProvider).onResume();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = ref.watch(desktopUpdateControllerProvider);
+    if (!controller.isDesktop) return widget.child;
+    final reducedMotion = MediaQuery.disableAnimationsOf(context);
+    return Stack(fit: StackFit.expand, children: [
+      widget.child,
+      Positioned(right: 16, bottom: 16,
+        child: ListenableBuilder(listenable: controller, builder: (context, _) =>
+          AnimatedSwitcher(
+            duration: reducedMotion ? Duration.zero : const Duration(milliseconds: 240),
+            transitionBuilder: (child, animation) => FadeTransition(opacity: animation,
+              child: SlideTransition(position: Tween<Offset>(
+                begin: const Offset(0, 0.12), end: Offset.zero,
+              ).animate(CurvedAnimation(parent: animation, curve: Curves.easeOutCubic)), child: child)),
+            child: controller.popupVisible
+                ? DesktopUpdatePopup(key: const ValueKey('desktop-update-popup'), controller: controller)
+                : const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    ]);
+  }
+}
+
+class DesktopUpdatePopup extends StatelessWidget {
+  const DesktopUpdatePopup({required this.controller, super.key});
+  final DesktopUpdateController controller;
+
+  @override
+  Widget build(BuildContext context) => ListenableBuilder(
+    listenable: controller,
+    builder: (context, _) {
+      final copy = UpdateCopy.of(context);
+      final theme = Theme.of(context);
+      final offer = controller.offer;
+      final size = MediaQuery.sizeOf(context);
+      final reducedMotion = MediaQuery.disableAnimationsOf(context);
+      final duration = reducedMotion ? Duration.zero : const Duration(milliseconds: 240);
+      return Semantics(container: true, label: copy.title,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxWidth: math.max(0.0, math.min(368.0, size.width - 32)),
+            maxHeight: math.max(0.0, math.min(480.0, size.height - 32)),
+          ),
+          child: Card(margin: EdgeInsets.zero, elevation: 8,
+            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14),
+              side: BorderSide(color: theme.colorScheme.outlineVariant)),
+            child: SingleChildScrollView(child: Padding(padding: const EdgeInsets.all(18),
+              child: Column(mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start, children: [
+                  Row(children: [
+                    Icon(Icons.system_update_alt, color: theme.colorScheme.primary),
+                    const SizedBox(width: 10),
+                    Expanded(child: Text(copy.title, style: theme.textTheme.titleMedium)),
+                    IconButton(key: const Key('desktop-update-close'),
+                      tooltip: copy.close, onPressed: controller.dismiss,
+                      icon: const Text('×', style: TextStyle(fontSize: 26)),
+                    ),
+                  ]),
+                  if (offer != null) ...[
+                    const SizedBox(height: 4),
+                    Text(copy.version(offer.version.text), key: const Key('desktop-update-version'),
+                      style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700)),
+                  ],
+                  const SizedBox(height: 10),
+                  Semantics(liveRegion: true, child: AnimatedSwitcher(duration: duration,
+                    child: Align(key: ValueKey(controller.phase), alignment: Alignment.centerLeft,
+                      child: Text(copy.phase(controller.phase), style: theme.textTheme.bodyMedium)),
+                  )),
+                  if (controller.busy) ...[
+                    const SizedBox(height: 14),
+                    TweenAnimationBuilder<double>(
+                      tween: Tween(begin: 0, end: controller.progress ?? 0), duration: duration,
+                      builder: (context, value, _) => LinearProgressIndicator(
+                        key: const Key('desktop-update-progress'), minHeight: 6,
+                        borderRadius: BorderRadius.circular(6),
+                        value: controller.progress == null ? (reducedMotion ? 0.5 : null) : value,
+                      ),
+                    ),
+                    if (controller.progress != null)
+                      Padding(padding: const EdgeInsets.only(top: 6), child: Text(
+                        '${(controller.progress! * 100).round()}%', style: theme.textTheme.labelSmall)),
+                  ],
+                  if (controller.error != null) ...[
+                    const SizedBox(height: 10),
+                    Text(controller.error!, key: const Key('desktop-update-error'),
+                      style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.error)),
+                  ],
+                  if (offer != null && offer.notes.isNotEmpty && !controller.busy) ...[
+                    const SizedBox(height: 12),
+                    ConstrainedBox(constraints: const BoxConstraints(maxHeight: 100),
+                      child: SingleChildScrollView(child: Text(offer.notes,
+                        style: theme.textTheme.bodySmall))),
+                  ],
+                  const SizedBox(height: 14),
+                  Text(copy.restart, style: theme.textTheme.bodySmall),
+                  const SizedBox(height: 12),
+                  Wrap(alignment: WrapAlignment.end, spacing: 8, runSpacing: 8, children: [
+                    if (offer != null) TextButton(onPressed: () async {
+                      try { await launchUrl(offer.releaseUrl, mode: LaunchMode.externalApplication); }
+                      catch (_) { /* Release notes are also visible in this card. */ }
+                    }, child: Text(copy.notes)),
+                    if (offer != null) FilledButton.icon(
+                      key: const Key('desktop-update-install'),
+                      onPressed: controller.busy ? null : () => unawaited(controller.update()),
+                      icon: const Icon(Icons.download_rounded, size: 18), label: Text(copy.update)),
+                    if (offer == null) OutlinedButton(
+                      onPressed: controller.busy ? null : () => unawaited(controller.check(manual: true)),
+                      child: Text(copy.check)),
+                  ]),
+                ],
+              ),
+            )),
+          ),
+        ),
+      );
+    },
+  );
+}
+
+class DesktopUpdateSettings extends ConsumerWidget {
+  const DesktopUpdateSettings({super.key});
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = ref.watch(desktopUpdateControllerProvider);
+    if (!controller.isDesktop) return const SizedBox.shrink();
+    return ListenableBuilder(listenable: controller, builder: (context, _) {
+      final copy = UpdateCopy.of(context);
+      if (!controller.enabled) {
+        return Padding(padding: const EdgeInsets.symmetric(vertical: 12), child: Text(copy.unsupported));
+      }
+      return Column(key: const Key('desktop-update-settings'),
+        crossAxisAlignment: CrossAxisAlignment.start, children: [
+          const Divider(height: 28),
+          Text(copy.settings, style: Theme.of(context).textTheme.titleMedium),
+          SwitchListTile.adaptive(key: const Key('desktop-update-rc'),
+            contentPadding: EdgeInsets.zero, title: Text(copy.rc), subtitle: Text(copy.rcHelp),
+            value: controller.channel == UpdateChannel.rc,
+            onChanged: controller.busy ? null : (enabled) => unawaited(controller.setChannel(
+              enabled ? UpdateChannel.rc : UpdateChannel.stable)),
+          ),
+          Text(controller.channel == UpdateChannel.stable ? copy.stable : copy.rcChannel),
+          const SizedBox(height: 8),
+          Text(controller.error ?? copy.phase(controller.phase),
+            key: const Key('desktop-update-settings-status'),
+            style: Theme.of(context).textTheme.bodySmall),
+          const SizedBox(height: 12),
+          OutlinedButton.icon(key: const Key('desktop-update-check'),
+            onPressed: controller.busy ? null : () => unawaited(controller.check(manual: true)),
+            icon: const Icon(Icons.refresh), label: Text(copy.check)),
+        ],
+      );
+    });
+  }
+}

--- a/lib/features/updates/update_widgets.dart
+++ b/lib/features/updates/update_widgets.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import 'update_contracts.dart';
 import 'update_controller.dart';
 import 'update_copy.dart';
 import 'update_providers.dart';

--- a/test/desktop_update_controller_test.dart
+++ b/test/desktop_update_controller_test.dart
@@ -1,0 +1,234 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pomodoist/features/updates/update_contracts.dart';
+import 'package:pomodoist/features/updates/update_controller.dart';
+import 'package:pomodoist/features/updates/update_release.dart';
+
+UpdateOffer testOffer([String tag = 'v1.1.0']) => UpdateOffer(
+  tag: tag, version: UpdateVersion.parse(tag), notes: 'Faster task lists.',
+  asset: UpdateAsset(name: 'Pomodoist-x86_64.AppImage', size: 12,
+    sha256: 'a' * 64,
+    url: Uri.parse('https://github.com/Kabanya/Pomodoist/releases/download/$tag/Pomodoist-x86_64.AppImage')),
+);
+
+class MemoryUpdatePreferences implements UpdatePreferences {
+  UpdateChannel channel = UpdateChannel.stable;
+  Set<String> seen = {};
+  bool failWrites = false;
+  @override
+  Future<SavedUpdatePreferences> load() async =>
+      SavedUpdatePreferences(channel: channel, seenTags: {...seen});
+  @override
+  Future<void> setChannel(UpdateChannel value) async {
+    if (failWrites) throw StateError('Storage unavailable');
+    channel = value;
+  }
+  @override
+  Future<void> markSeen(Set<String> tags) async {
+    if (failWrites) throw StateError('Storage unavailable');
+    seen = {...tags};
+  }
+}
+
+class FakeUpdateSource implements UpdateSource {
+  UpdateOffer? offer = testOffer();
+  UpdateChannel? lastChannel;
+  int calls = 0;
+  Completer<void>? gate;
+  bool fail = false;
+  @override
+  Future<UpdateOffer?> findUpdate({required UpdateVersion current,
+    required UpdateTarget target, required UpdateChannel channel}) async {
+    calls++;
+    lastChannel = channel;
+    await gate?.future;
+    if (fail) throw const UpdateFailure('Network unavailable');
+    return offer;
+  }
+  @override
+  void dispose() {}
+}
+
+class FakeUpdateInstaller implements UpdateInstaller {
+  int installs = 0;
+  int acknowledgements = 0;
+  bool fail = false;
+  Completer<void>? gate;
+  UpdateProgress? report;
+  @override
+  UpdateTarget? target = const UpdateTarget(UpdateOS.linux, UpdateArch.x64);
+  @override
+  String? unavailableReason;
+  @override
+  Future<String?> acknowledgeStartup() async { acknowledgements++; return null; }
+  @override
+  Future<void> install(UpdateOffer offer, UpdateProgress progress) async {
+    installs++;
+    report = progress;
+    progress(UpdatePhase.downloading, 0.25);
+    await gate?.future;
+    if (fail) throw const UpdateFailure('Checksum mismatch');
+    progress(UpdatePhase.verifying, null);
+    progress(UpdatePhase.installing, null);
+  }
+  @override
+  void dispose() {}
+}
+
+DesktopUpdateController testController({FakeUpdateSource? source,
+  FakeUpdateInstaller? installer, MemoryUpdatePreferences? preferences,
+  bool automaticChecks = false}) => DesktopUpdateController(
+    source: source ?? FakeUpdateSource(), installer: installer ?? FakeUpdateInstaller(),
+    preferences: preferences ?? MemoryUpdatePreferences(),
+    installedVersion: () async => '1.0.0+94', automaticChecks: automaticChecks);
+
+void main() {
+  test('stable is default and showing a release persists its tag', () async {
+    final prefs = MemoryUpdatePreferences();
+    final source = FakeUpdateSource();
+    final controller = testController(source: source, preferences: prefs);
+    addTearDown(controller.dispose);
+    await controller.check();
+    expect(source.lastChannel, UpdateChannel.stable);
+    expect(controller.popupVisible, isTrue);
+    expect(prefs.seen, {'v1.1.0'});
+  });
+
+  test('dismissal does not install or repeat after restart; manual check reopens', () async {
+    final prefs = MemoryUpdatePreferences();
+    final installer = FakeUpdateInstaller();
+    final first = testController(preferences: prefs, installer: installer);
+    await first.check();
+    first.dismiss();
+    await first.check();
+    expect(first.popupVisible, isFalse);
+    expect(installer.installs, 0);
+    first.dispose();
+    final restarted = testController(preferences: prefs);
+    addTearDown(restarted.dispose);
+    await restarted.check();
+    expect(restarted.popupVisible, isFalse);
+    await restarted.check(manual: true);
+    expect(restarted.popupVisible, isTrue);
+  });
+
+  test('a distinct release gets its own automatic popup', () async {
+    final source = FakeUpdateSource();
+    final controller = testController(source: source);
+    addTearDown(controller.dispose);
+    await controller.check();
+    controller.dismiss();
+    source.offer = testOffer('v1.2.0');
+    await controller.check();
+    expect(controller.popupVisible, isTrue);
+    expect(controller.offer!.tag, 'v1.2.0');
+  });
+
+  test('RC channel persists and is used after restart', () async {
+    final prefs = MemoryUpdatePreferences();
+    final first = testController(preferences: prefs);
+    await first.setChannel(UpdateChannel.rc);
+    first.dispose();
+    final source = FakeUpdateSource();
+    final next = testController(preferences: prefs, source: source);
+    addTearDown(next.dispose);
+    await next.check();
+    expect(source.lastChannel, UpdateChannel.rc);
+    expect(next.channel, UpdateChannel.rc);
+  });
+
+  test('a failed channel write cannot silently opt into RC', () async {
+    final prefs = MemoryUpdatePreferences()..failWrites = true;
+    final controller = testController(preferences: prefs);
+    addTearDown(controller.dispose);
+    await controller.setChannel(UpdateChannel.rc);
+    expect(controller.channel, UpdateChannel.stable);
+    expect(controller.phase, UpdatePhase.failed);
+  });
+
+  test('concurrent checks are coalesced', () async {
+    final source = FakeUpdateSource()..gate = Completer<void>();
+    final controller = testController(source: source);
+    addTearDown(controller.dispose);
+    final checking = controller.check();
+    await controller.check();
+    source.gate!.complete();
+    await checking;
+    expect(source.calls, 1);
+  });
+
+  test('failed download remains retryable and does not repeat installation', () async {
+    final installer = FakeUpdateInstaller()..fail = true;
+    final controller = testController(installer: installer);
+    addTearDown(controller.dispose);
+    await controller.check();
+    await controller.update();
+    expect(controller.phase, UpdatePhase.failed);
+    expect(controller.error, contains('Checksum'));
+    expect(controller.offer, isNotNull);
+    installer.fail = false;
+    await controller.update();
+    expect(installer.installs, 2);
+    expect(controller.phase, UpdatePhase.installing);
+  });
+
+  test('duplicate Update clicks cannot start concurrent installers', () async {
+    final installer = FakeUpdateInstaller()..gate = Completer<void>();
+    final controller = testController(installer: installer);
+    addTearDown(controller.dispose);
+    await controller.check();
+    final updating = controller.update();
+    await controller.update();
+    expect(installer.installs, 1);
+    installer.gate!.complete();
+    await updating;
+  });
+
+  test('stable channel refuses even an incorrectly injected RC offer', () async {
+    final source = FakeUpdateSource()..offer = testOffer('v2.0.0-rc.1');
+    final installer = FakeUpdateInstaller();
+    final controller = testController(source: source, installer: installer);
+    addTearDown(controller.dispose);
+    await controller.check();
+    await controller.update();
+    expect(installer.installs, 0);
+  });
+
+  test('offline checks are quiet automatically and visible manually', () async {
+    final source = FakeUpdateSource()..fail = true;
+    final controller = testController(source: source);
+    addTearDown(controller.dispose);
+    await controller.check();
+    expect(controller.phase, UpdatePhase.failed);
+    expect(controller.popupVisible, isFalse);
+    expect(controller.lastChecked, isNotNull);
+    await controller.check(manual: true);
+    expect(controller.popupVisible, isTrue);
+  });
+
+  test('unsupported platforms do not access the network', () async {
+    final source = FakeUpdateSource();
+    final installer = FakeUpdateInstaller()..target = null;
+    final controller = testController(source: source, installer: installer);
+    addTearDown(controller.dispose);
+    await controller.start();
+    await controller.check(manual: true);
+    expect(source.calls, 0);
+    expect(controller.isDesktop, isFalse);
+  });
+
+  testWidgets('automatic checks start after startup delay and recur', (tester) async {
+    final source = FakeUpdateSource();
+    final installer = FakeUpdateInstaller();
+    final controller = testController(source: source, installer: installer, automaticChecks: true);
+    await controller.start();
+    expect(installer.acknowledgements, 1);
+    expect(source.calls, 0);
+    await tester.pump(const Duration(seconds: 11));
+    expect(source.calls, 1);
+    await tester.pump(const Duration(hours: 6));
+    expect(source.calls, 2);
+    controller.dispose();
+  });
+}

--- a/test/desktop_update_network_test.dart
+++ b/test/desktop_update_network_test.dart
@@ -1,0 +1,142 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pomodoist/features/updates/github_update_source.dart';
+import 'package:pomodoist/features/updates/update_contracts.dart';
+import 'package:pomodoist/features/updates/update_downloader_io.dart';
+import 'package:pomodoist/features/updates/update_release.dart';
+
+import 'desktop_update_release_test.dart' as fixtures;
+
+class _Adapter implements HttpClientAdapter {
+  _Adapter(this.respond);
+  final FutureOr<ResponseBody> Function(RequestOptions) respond;
+  @override
+  Future<ResponseBody> fetch(RequestOptions options, Stream<Uint8List>? requestStream,
+      Future<void>? cancelFuture) async => respond(options);
+  @override
+  void close({bool force = false}) {}
+}
+
+Dio client(FutureOr<ResponseBody> Function(RequestOptions) respond) =>
+    Dio()..httpClientAdapter = _Adapter(respond);
+ResponseBody jsonResponse(Object body, [int status = 200]) =>
+    ResponseBody.fromString(jsonEncode(body), status,
+      headers: {Headers.contentTypeHeader: [Headers.jsonContentType]});
+UpdateOffer binaryOffer(List<int> bytes, {String? digest, int? size, UpdateAsset? checksum}) => UpdateOffer(
+  tag: 'v2.0.0', version: UpdateVersion.parse('2.0.0'), notes: '', checksum: checksum,
+  asset: UpdateAsset(name: 'Pomodoist-x86_64.AppImage', size: size ?? bytes.length,
+    sha256: digest ?? sha256.convert(bytes).toString(),
+    url: Uri.parse('https://github.com/Kabanya/Pomodoist/releases/download/v2.0.0/Pomodoist-x86_64.AppImage')),
+);
+
+void main() {
+  test('release discovery reads subsequent pages and uses semantic precedence', () async {
+    final pages = <int>[];
+    final source = GitHubUpdateSource(dio: client((request) {
+      final page = request.queryParameters['page'] as int;
+      pages.add(page);
+      expect(request.headers['Authorization'], isNull);
+      return jsonResponse(page == 1
+        ? List.generate(100, (_) => fixtures.releaseFixture('v1.2.0'))
+        : [fixtures.releaseFixture('v9.0.0')]);
+    }));
+    addTearDown(source.dispose);
+    final found = await source.findUpdate(current: UpdateVersion.parse('1.0.0'),
+      target: fixtures.linuxTarget, channel: UpdateChannel.stable);
+    expect(pages, [1, 2]);
+    expect(found!.tag, 'v9.0.0');
+  });
+
+  test('GitHub rate limits produce a retryable error', () async {
+    final source = GitHubUpdateSource(dio: client((_) => jsonResponse({}, 429)));
+    addTearDown(source.dispose);
+    await expectLater(source.findUpdate(current: UpdateVersion.parse('1.0.0'),
+      target: fixtures.linuxTarget, channel: UpdateChannel.stable),
+      throwsA(isA<UpdateFailure>().having((e) => e.message, 'message', contains('rate limit'))));
+  });
+
+  group('verified downloads', () {
+    late Directory stage;
+    setUp(() async { stage = await Directory.systemTemp.createTemp('pomodoist-download-test-'); });
+    tearDown(() async { await stage.delete(recursive: true); });
+
+    test('streams correct bytes and verifies before promoting the artifact', () async {
+      final bytes = utf8.encode('verified release payload');
+      final downloader = UpdateDownloader(dio: client((_) => ResponseBody.fromBytes(bytes, 200)));
+      addTearDown(downloader.dispose);
+      final destination = File('${stage.path}/release');
+      final phases = <UpdatePhase>[];
+      final hash = await downloader.download(binaryOffer(bytes), destination, (phase, _) => phases.add(phase));
+      expect(await destination.readAsBytes(), bytes);
+      expect(hash, sha256.convert(bytes).toString());
+      expect(phases, containsAllInOrder([UpdatePhase.downloading, UpdatePhase.verifying]));
+      expect(await File('${destination.path}.part').exists(), isFalse);
+    });
+
+    test('corrupt digest is rejected and no executable or partial file remains', () async {
+      final bytes = utf8.encode('corrupted');
+      final downloader = UpdateDownloader(dio: client((_) => ResponseBody.fromBytes(bytes, 200)));
+      addTearDown(downloader.dispose);
+      final destination = File('${stage.path}/release');
+      await expectLater(downloader.download(binaryOffer(bytes, digest: 'a' * 64), destination, (_, _) {}),
+        throwsA(isA<UpdateFailure>()));
+      expect(await destination.exists(), isFalse);
+      expect(await File('${destination.path}.part').exists(), isFalse);
+    });
+
+    for (final delta in [-1, 1]) {
+      test('incorrect byte count ($delta) leaves no installable artifact', () async {
+        final bytes = utf8.encode('payload');
+        final downloader = UpdateDownloader(dio: client((_) => ResponseBody.fromBytes(bytes, 200)));
+        addTearDown(downloader.dispose);
+        final destination = File('${stage.path}/release');
+        await expectLater(downloader.download(binaryOffer(bytes, size: bytes.length + delta), destination, (_, _) {}),
+          throwsA(isA<UpdateFailure>()));
+        expect(await destination.exists(), isFalse);
+        expect(await File('${destination.path}.part').exists(), isFalse);
+      });
+    }
+
+    test('interrupted stream cleans up its partial file', () async {
+      final bytes = utf8.encode('payload');
+      Stream<Uint8List> interrupted() async* {
+        yield Uint8List.fromList(bytes.take(2).toList());
+        throw const SocketException('interrupted');
+      }
+      final downloader = UpdateDownloader(dio: client((_) => ResponseBody(interrupted(), 200)));
+      addTearDown(downloader.dispose);
+      final destination = File('${stage.path}/release');
+      await expectLater(downloader.download(binaryOffer(bytes), destination, (_, _) {}), throwsA(isA<Exception>()));
+      expect(await destination.exists(), isFalse);
+      expect(await File('${destination.path}.part').exists(), isFalse);
+    });
+
+    for (final redirect in ['http://github.com/file', 'https://evil.example/release.exe']) {
+      test('rejects untrusted redirect $redirect', () async {
+        final downloader = UpdateDownloader(dio: client((_) => ResponseBody.fromBytes([], 302,
+          headers: {'location': [redirect]})));
+        addTearDown(downloader.dispose);
+        await expectLater(downloader.download(binaryOffer([1]), File('${stage.path}/release'), (_, _) {}),
+          throwsA(isA<UpdateFailure>()));
+      });
+    }
+
+    test('mismatched sidecar and API digest fail before fetching executable', () async {
+      final checksum = utf8.encode('${'b' * 64} *Pomodoist-x86_64.AppImage\n');
+      var requests = 0;
+      final downloader = UpdateDownloader(dio: client((_) { requests++; return ResponseBody.fromBytes(checksum, 200); }));
+      addTearDown(downloader.dispose);
+      final offer = binaryOffer([1], digest: 'a' * 64, checksum: UpdateAsset(
+        name: 'Pomodoist-x86_64.AppImage.sha256', size: checksum.length,
+        url: Uri.parse('https://github.com/Kabanya/Pomodoist/releases/download/v2.0.0/Pomodoist-x86_64.AppImage.sha256')));
+      await expectLater(downloader.download(offer, File('${stage.path}/release'), (_, _) {}), throwsA(isA<UpdateFailure>()));
+      expect(requests, 1);
+    });
+  });
+}

--- a/test/desktop_update_release_test.dart
+++ b/test/desktop_update_release_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pomodoist/features/updates/update_release.dart';
+
+Map<String, Object?> releaseFixture(
+  String tag, {
+  bool draft = false,
+  bool prerelease = false,
+  String name = 'Pomodoist-x86_64.AppImage',
+  bool checksum = true,
+  String? digest,
+  String? url,
+}) => {
+  'tag_name': tag,
+  'draft': draft,
+  'prerelease': prerelease,
+  'body': 'Release notes for $tag',
+  'assets': [
+    {
+      'name': name,
+      'size': 100,
+      'state': 'uploaded',
+      'digest': digest,
+      'browser_download_url': url ??
+          'https://github.com/Kabanya/Pomodoist/releases/download/$tag/$name',
+    },
+    if (checksum)
+      {
+        'name': '$name.sha256',
+        'size': 100,
+        'state': 'uploaded',
+        'browser_download_url':
+            'https://github.com/Kabanya/Pomodoist/releases/download/$tag/$name.sha256',
+      },
+  ],
+};
+
+const linuxTarget = UpdateTarget(UpdateOS.linux, UpdateArch.x64);
+
+void main() {
+  group('SemVer', () {
+    test('compares numbers, RC identifiers and stable precedence', () {
+      final versions = [
+        '1.9.0', '1.10.0-rc.2', '1.10.0-rc.10', '1.10.0', '2.0.0',
+      ].map(UpdateVersion.parse).toList();
+      for (var i = 1; i < versions.length; i++) {
+        expect(versions[i].compareTo(versions[i - 1]), greaterThan(0));
+      }
+    });
+    test('build metadata is not precedence', () {
+      expect(UpdateVersion.parse('v1.2.3+94').compareTo(
+        UpdateVersion.parse('1.2.3+95')), 0);
+    });
+    for (final value in ['1.2', '01.2.3', '1.2.3-rc.01', '1.2.3-', 'latest', '1.2.3+']) {
+      test('rejects malformed version $value', () {
+        expect(UpdateVersion.tryParse(value), isNull);
+      });
+    }
+  });
+
+  UpdateOffer? select(List<Object?> releases, {
+    UpdateChannel channel = UpdateChannel.stable,
+    String current = '1.0.0',
+    UpdateTarget target = linuxTarget,
+  }) => selectUpdate(releases, current: UpdateVersion.parse(current),
+    target: target, channel: channel);
+
+  test('stable ignores drafts, flagged prereleases, alpha, beta and RC', () {
+    expect(select([
+      releaseFixture('v3.0.0', draft: true),
+      releaseFixture('v2.8.0', prerelease: true),
+      releaseFixture('v2.7.0-alpha.1'),
+      releaseFixture('v2.6.0-beta.1'),
+      releaseFixture('v2.5.0-rc.1'),
+      releaseFixture('v2.0.0'),
+    ])?.tag, 'v2.0.0');
+  });
+  test('RC includes RC and stable, never unrelated prereleases', () {
+    expect(select([
+      releaseFixture('v3.0.0-beta.1', prerelease: true),
+      releaseFixture('v2.0.0-rc.2', prerelease: true),
+      releaseFixture('v2.0.0-rc.10', prerelease: true),
+    ], channel: UpdateChannel.rc)?.tag, 'v2.0.0-rc.10');
+    expect(select([
+      releaseFixture('v2.0.0'),
+      releaseFixture('v2.0.0-rc.10', prerelease: true),
+    ], channel: UpdateChannel.rc)?.tag, 'v2.0.0');
+  });
+  test('sorts by version, not API publication order', () {
+    expect(select([releaseFixture('v1.1.0'), releaseFixture('v2.0.0'),
+      releaseFixture('v1.9.0')])?.tag, 'v2.0.0');
+  });
+  test('never downgrades RC or reinstalls metadata-only changes', () {
+    expect(select([releaseFixture('v1.9.0')], current: '2.0.0-rc.1'), isNull);
+    expect(select([releaseFixture('v2.0.0+96')], current: '2.0.0+94'), isNull);
+    expect(select([releaseFixture('v2.0.0')], current: '2.0.0-rc.1')?.tag, 'v2.0.0');
+  });
+  test('requires the exact architecture, never a substring match', () {
+    expect(select([releaseFixture('v2.0.0', name: 'Pomodoist-aarch64.AppImage')]), isNull);
+    expect(select([releaseFixture('v2.0.0', name: 'Pomodoist-x86_64.AppImage.exe')]), isNull);
+    expect(select([releaseFixture('v2.0.0', name: 'Pomodoist-aarch64.AppImage')],
+      target: const UpdateTarget(UpdateOS.linux, UpdateArch.arm64))?.tag, 'v2.0.0');
+  });
+  test('legacy Windows installer is x64 only', () {
+    final release = releaseFixture('v2.0.0', name: 'Pomodoist-Setup.exe');
+    expect(select([release], target: const UpdateTarget(UpdateOS.windows, UpdateArch.x64)), isNotNull);
+    expect(select([release], target: const UpdateTarget(UpdateOS.windows, UpdateArch.arm64)), isNull);
+  });
+  test('fails closed without integrity metadata', () {
+    expect(select([releaseFixture('v2.0.0', checksum: false)]), isNull);
+    expect(select([releaseFixture('v2.0.0', checksum: false, digest: 'sha256:${'a' * 64}')]), isNotNull);
+    expect(select([releaseFixture('v2.0.0', checksum: false, digest: 'md5:abc')]), isNull);
+  });
+  for (final url in [
+    'http://github.com/Kabanya/Pomodoist/releases/download/v2.0.0/Pomodoist-x86_64.AppImage',
+    'https://evil.example/Pomodoist-x86_64.AppImage',
+    'https://github.com/other/repo/releases/download/v2.0.0/Pomodoist-x86_64.AppImage',
+    'https://github.com/Kabanya/Pomodoist/releases/download/v1.0.0/Pomodoist-x86_64.AppImage',
+  ]) {
+    test('rejects untrusted or cross-release asset URL $url', () {
+      expect(select([releaseFixture('v2.0.0', url: url)]), isNull);
+    });
+  }
+  test('malformed release entries do not hide a valid update', () {
+    expect(select([null, {}, {'tag_name': 42}, releaseFixture('v2.0.0')])?.tag, 'v2.0.0');
+  });
+  test('checksum is bound to the exact artifact filename', () {
+    final hash = 'a' * 64;
+    expect(parseUpdateChecksum('$hash *Pomodoist-Setup.exe\r\n', 'Pomodoist-Setup.exe'), hash);
+    expect(() => parseUpdateChecksum('$hash other.exe', 'Pomodoist-Setup.exe'), throwsFormatException);
+    expect(() => parseUpdateChecksum(hash, 'Pomodoist-Setup.exe'), throwsFormatException);
+  });
+}

--- a/test/desktop_update_widgets_test.dart
+++ b/test/desktop_update_widgets_test.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pomodoist/features/updates/update_contracts.dart';
+import 'package:pomodoist/features/updates/update_providers.dart';
+import 'package:pomodoist/features/updates/update_widgets.dart';
+import 'package:pomodoist/features/updates/update_release.dart';
+
+import 'desktop_update_controller_test.dart' as support;
+
+void main() {
+  testWidgets('bottom-right popup shows version, closes without installing, stays dismissed', (tester) async {
+    final installer = support.FakeUpdateInstaller();
+    final controller = support.testController(installer: installer);
+    await controller.check();
+    await tester.pumpWidget(ProviderScope(overrides: [
+      desktopUpdateControllerProvider.overrideWithValue(controller),
+    ], child: const MaterialApp(home: DesktopUpdateHost(child: Scaffold()))));
+    await tester.pumpAndSettle();
+    expect(find.text('×'), findsOneWidget);
+    expect(find.byKey(const Key('desktop-update-version')), findsOneWidget);
+    expect(find.byKey(const Key('desktop-update-install')), findsOneWidget);
+    final popup = tester.getRect(find.byType(DesktopUpdatePopup));
+    expect(popup.right, closeTo(784, 1));
+    expect(popup.bottom, closeTo(584, 1));
+    await tester.tap(find.byKey(const Key('desktop-update-close')));
+    await tester.pumpAndSettle();
+    expect(find.byType(DesktopUpdatePopup), findsNothing);
+    expect(installer.installs, 0);
+    await controller.check();
+    await tester.pumpAndSettle();
+    expect(find.byType(DesktopUpdatePopup), findsNothing);
+    await tester.pumpWidget(const SizedBox.shrink());
+    controller.dispose();
+  });
+
+  testWidgets('Update starts exactly once and animates download, verification and installation', (tester) async {
+    final installer = support.FakeUpdateInstaller()..gate = Completer<void>();
+    final controller = support.testController(installer: installer);
+    await controller.check();
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: DesktopUpdatePopup(controller: controller))));
+    await tester.tap(find.byKey(const Key('desktop-update-install')));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(installer.installs, 1);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(find.textContaining('25%'), findsOneWidget);
+    await tester.tap(find.byKey(const Key('desktop-update-install')));
+    expect(installer.installs, 1);
+    installer.report!(UpdatePhase.verifying, null);
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(find.text('Verifying integrity…'), findsOneWidget);
+    installer.gate!.complete();
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(controller.phase, UpdatePhase.installing);
+    await tester.pumpWidget(const SizedBox.shrink());
+    controller.dispose();
+  });
+
+  testWidgets('Settings can enable RC and manually check updates', (tester) async {
+    final source = support.FakeUpdateSource();
+    final controller = support.testController(source: source);
+    await tester.pumpWidget(ProviderScope(overrides: [
+      desktopUpdateControllerProvider.overrideWithValue(controller),
+    ], child: const MaterialApp(home: Scaffold(body: DesktopUpdateSettings()))));
+    await tester.tap(find.byKey(const Key('desktop-update-rc')));
+    await tester.pumpAndSettle();
+    expect(controller.channel, UpdateChannel.rc);
+    expect(source.lastChannel, UpdateChannel.rc);
+    final before = source.calls;
+    await tester.tap(find.byKey(const Key('desktop-update-check')));
+    await tester.pumpAndSettle();
+    expect(source.calls, before + 1);
+    await tester.pumpWidget(const SizedBox.shrink());
+    controller.dispose();
+  });
+
+  testWidgets('compact window and reduced motion do not overflow or keep animating', (tester) async {
+    tester.view.physicalSize = const Size(360, 640);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final controller = support.testController();
+    await controller.check();
+    controller.phase = UpdatePhase.verifying;
+    await tester.pumpWidget(MaterialApp(home: MediaQuery(
+      data: const MediaQueryData(size: Size(360, 640), disableAnimations: true),
+      child: Scaffold(body: DesktopUpdatePopup(controller: controller)))));
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox.shrink());
+    controller.dispose();
+  });
+}

--- a/tool/test_desktop_update_helpers.py
+++ b/tool/test_desktop_update_helpers.py
@@ -1,0 +1,100 @@
+"""Exercise the actual bundled POSIX helper using isolated fake AppImages."""
+import hashlib
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / 'lib/features/updates/update_install_scripts.dart'
+
+
+def bundled_script(name):
+    source = SCRIPTS.read_text()
+    match = re.search(r"const " + name + r" = r'''\n(.*?)\n''';", source, re.S)
+    if not match:
+        raise AssertionError(f'Missing bundled helper {name}')
+    return match.group(1) + '\n'
+
+
+@unittest.skipUnless(os.name == 'posix', 'POSIX helper')
+class AppImageUpdateTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="pomodoist ' test ")
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.stage = self.root / '.pomodoist-update-test'
+        self.stage.mkdir()
+        self.target = self.root / 'Pomodoist with spaces.AppImage'
+        self.marker = self.root / 'launched'
+        self.old = '#!/bin/sh\nprintf old > "' + str(self.marker) + '"\n'
+        self.target.write_text(self.old)
+        self.target.chmod(0o755)
+        self.payload = self.stage / 'update.AppImage'
+        self.payload.write_text(
+            '#!/bin/sh\nprintf new > "' + str(self.marker) + '"\n'
+            'printf started > "$POMODOIST_UPDATE_READY_FILE"\n'
+        )
+        self.script = self.stage / 'install.sh'
+        self.script.write_text(bundled_script('linuxUpdateScript'))
+
+    def run_helper(self, digest=None, parent='2147483647'):
+        digest = digest or hashlib.sha256(self.payload.read_bytes()).hexdigest()
+        return subprocess.run(
+            ['/bin/sh', str(self.script), parent, str(self.target),
+             str(self.payload), digest],
+            capture_output=True, text=True, timeout=20,
+        )
+
+    def test_success_replaces_original_path_and_restarts(self):
+        expected = self.payload.read_bytes()
+        result = self.run_helper()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self.target.read_bytes(), expected)
+        self.assertTrue(os.access(self.target, os.X_OK))
+        self.assertEqual(self.marker.read_text(), 'new')
+        self.assertEqual((self.stage / 'result').read_text().strip(), 'success')
+
+    def test_bad_hash_preserves_original_without_launching(self):
+        result = self.run_helper('0' * 64)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.target.read_text(), self.old)
+        self.assertFalse(self.marker.exists())
+
+    def test_cancel_preserves_running_application(self):
+        (self.stage / 'cancel').touch()
+        result = self.run_helper(parent=str(os.getpid()))
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.target.read_text(), self.old)
+        self.assertFalse(self.marker.exists())
+
+    def test_failed_new_executable_rolls_back(self):
+        self.payload.write_text('#!/bin/sh\nexit 17\n')
+        result = self.run_helper()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.target.read_text(), self.old)
+        self.assertEqual(self.marker.read_text(), 'old')
+        self.assertEqual((self.stage / 'result').read_text().strip(), 'failed')
+
+    def test_rejects_symlink_target(self):
+        real = self.root / 'real.AppImage'
+        self.target.rename(real)
+        self.target.symlink_to(real)
+        result = self.run_helper()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertTrue(self.target.is_symlink())
+        self.assertEqual(real.read_text(), self.old)
+
+    def test_second_helper_cannot_replace_locked_appimage(self):
+        lock = Path(str(self.target) + '.update-lock')
+        lock.mkdir()
+        (lock / 'pid').write_text(str(os.getpid()))
+        result = self.run_helper()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.target.read_text(), self.old)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tool/test_desktop_update_windows.ps1
+++ b/tool/test_desktop_update_windows.ps1
@@ -92,3 +92,7 @@ try {
   Start-Sleep -Milliseconds 500
   Remove-Item -LiteralPath $base -Recurse -Force -ErrorAction SilentlyContinue
 }
+
+# Expected negative-case exit codes were asserted above. Do not leak the final
+# fixture's nonzero exit code into GitHub Actions' PowerShell wrapper.
+exit 0

--- a/tool/test_desktop_update_windows.ps1
+++ b/tool/test_desktop_update_windows.ps1
@@ -1,0 +1,94 @@
+# Executes the exact helper bundled in Dart with real Windows fixture executables.
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $PSScriptRoot
+$source = Get-Content -LiteralPath (Join-Path $root 'lib/features/updates/update_install_scripts.dart') -Raw
+$match = [regex]::Match($source, "(?s)const windowsUpdateScript = r'''\r?\n(.*?)''';")
+if (-not $match.Success) { throw 'Could not extract bundled Windows helper.' }
+$base = Join-Path ([IO.Path]::GetTempPath()) ("Pomodoist updater's test " + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $base | Out-Null
+$appSource = @'
+using System;
+using System.IO;
+public class FixtureApp {
+  public static int Main() {
+    string marker = Environment.GetEnvironmentVariable("POMODOIST_UPDATE_READY_FILE");
+    if (!String.IsNullOrEmpty(marker)) File.WriteAllText(marker, "started");
+    File.WriteAllText(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "launched"), "yes");
+    return 0;
+  }
+}
+'@
+$installerSource = @'
+using System;
+using System.IO;
+public class FixtureInstaller {
+  public static int Main(string[] args) {
+    string dir = null;
+    foreach (string arg in args) if (arg.StartsWith("/DIR=")) dir = arg.Substring(5).Trim('"');
+    if (String.IsNullOrEmpty(dir) || !Array.Exists(args, x => x == "/NORESTART") ||
+        !Array.Exists(args, x => x == "/NOCLOSEAPPLICATIONS")) return 64;
+    File.WriteAllText(Path.Combine(dir, "version"), "new");
+    string mode = Environment.GetEnvironmentVariable("POMODOIST_UPDATER_TEST_MODE");
+    if (mode == "fail") return 7;
+    if (mode == "broken") File.WriteAllText(Path.Combine(dir, "pomodoist.exe"), "not an executable");
+    return 0;
+  }
+}
+'@
+function Assert-True([bool]$Condition, [string]$Message) {
+  if (-not $Condition) { throw $Message }
+}
+try {
+  $compiler = Join-Path $env:WINDIR 'Microsoft.NET\Framework64\v4.0.30319\csc.exe'
+  foreach ($entry in @(@('app', $appSource), @('installer', $installerSource))) {
+    $cs = Join-Path $base ($entry[0] + '.cs')
+    $exe = Join-Path $base ($entry[0] + '.exe')
+    [IO.File]::WriteAllText($cs, $entry[1])
+    & $compiler /nologo /target:exe "/out:$exe" $cs
+    if ($LASTEXITCODE -ne 0) { throw 'Fixture compilation failed.' }
+  }
+  $checks = 0
+  foreach ($mode in @('success', 'fail', 'broken', 'hash', 'cancel')) {
+    $case = Join-Path $base $mode
+    $install = Join-Path $case 'Pomodoist'
+    $stage = Join-Path $case '.pomodoist-update-test'
+    New-Item -ItemType Directory -Path $install, $stage | Out-Null
+    $app = Join-Path $install 'pomodoist.exe'
+    $installer = Join-Path $stage 'Pomodoist-Setup.exe'
+    Copy-Item -LiteralPath (Join-Path $base 'app.exe') -Destination $app
+    Copy-Item -LiteralPath (Join-Path $base 'installer.exe') -Destination $installer
+    [IO.File]::WriteAllText((Join-Path $install 'version'), 'old')
+    $data = Join-Path $case 'user-data'
+    [IO.File]::WriteAllText($data, 'tasks settings auth')
+    $helper = Join-Path $stage 'install.ps1'
+    [IO.File]::WriteAllText($helper, $match.Groups[1].Value)
+    $hash = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash
+    if ($mode -eq 'hash') { $hash = '0' * 64 }
+    $env:POMODOIST_UPDATER_TEST_MODE = $mode
+    $parentId = 2147483647
+    if ($mode -eq 'cancel') {
+      $parentId = $PID
+      [IO.File]::WriteAllText((Join-Path $stage 'cancel'), 'cancel')
+    }
+    & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $helper `
+      -ParentProcessId $parentId -ApplicationPath $app -InstallerPath $installer -Sha256 $hash
+    $code = $LASTEXITCODE
+    if ($mode -eq 'success') {
+      Assert-True ($code -eq 0) 'Successful update helper failed.'
+      Assert-True ((Get-Content -LiteralPath (Join-Path $install 'version') -Raw) -eq 'new') 'New version not installed.'
+      Assert-True ((Get-Content -LiteralPath (Join-Path $stage 'result') -Raw).Trim() -eq 'success') 'Missing successful health check.'
+    } else {
+      Assert-True ($code -ne 0) "Expected rejection for $mode."
+      Assert-True ((Get-Content -LiteralPath (Join-Path $install 'version') -Raw) -eq 'old') "Old version not preserved for $mode."
+      Assert-True ((Get-FileHash -LiteralPath $app).Hash -eq (Get-FileHash -LiteralPath (Join-Path $base 'app.exe')).Hash) "Old executable not restored for $mode."
+    }
+    Assert-True ((Get-Content -LiteralPath $data -Raw) -eq 'tasks settings auth') 'User data was modified.'
+    $checks++
+    Write-Host "PASS: Windows helper $mode"
+  }
+  Write-Host "$checks Windows integration scenarios passed."
+} finally {
+  Remove-Item Env:POMODOIST_UPDATER_TEST_MODE -ErrorAction SilentlyContinue
+  Start-Sleep -Milliseconds 500
+  Remove-Item -LiteralPath $base -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
Implements the desktop updater for #58 on `58/automatic-updates-windows-linux`, created from main commit `323088c78f1f8dacf5f8d39c141b6fc0aaa60367`.

Current implementation commit: `dc4cda87db27ed44ae703221bd972f57d997df02`.

**Do not merge automatically. This PR remains a draft.**

- Stable-by-default semantic release selection, persistent opt-in RC channel, exact platform/architecture assets and once-per-tag automatic notifications.
- Bottom-right animated update card with version, release notes, × dismissal, Update action and manual checks in Settings.
- Bounded HTTPS downloads with exact byte count and SHA-256 verification; bundled Windows and AppImage install/restart helpers with backup, graceful-exit cancellation and rollback.
- No updater writes to the application database, authentication or application-data directories. No new dependencies and no release publishing.
- Unit/widget/network tests, executable native-helper integration scenarios and Linux/Windows build CI.

## Verified on the current implementation commit

| Check | Result |
| --- | --- |
| Desktop updater workflow | Passed: https://github.com/Kabanya/Pomodoist/actions/runs/34147644577 |
| Focused updater Flutter tests | 47 passed on Linux and 47 passed on Windows |
| Linux helper integration scenarios | 6 passed: replacement/restart, checksum rejection, cancellation, failed-launch rollback, symlink rejection and competing helper |
| Windows helper integration scenarios | 5 passed: success, installer failure, broken executable, checksum rejection and cancellation; fixture data preservation asserted |
| Native Linux debug build | Passed |
| Native Windows debug build | Passed |
| Flutter analyzer | Passed |
| General Flutter suite in first Validate attempt | 883 passed, 2 skipped |
| Browser tests in first Validate attempt | 2 passed |
| Android validation | Passed: https://github.com/Kabanya/Pomodoist/actions/runs/34147644568 |
| Self-hosted server | Passed: https://github.com/Kabanya/Pomodoist/actions/runs/34147644583 |
| Complete Validate workflow / debug web compilation | Not yet confirmed green: first attempt exited with code 137 during web compilation; the failed job was retried without weakening tests or changing code. Latest observed retry was still running: https://github.com/Kabanya/Pomodoist/actions/runs/34147644565 |

Fixed findings from the first updater CI pass: two analyzer findings, preservation of the original download/integrity error when its file sink has already closed, and an expected negative Windows fixture exit code leaking into the job status. Tests were not disabled or relaxed.

## Remaining release acceptance

The actual two-version upgrade smoke test in Windows 10/11 and an AppImage desktop session has **not** been performed. Native executable fixtures and successful builds are not a substitute for that manual acceptance pass. Do not mark the manual QA checklist complete on that basis.

See `docs/desktop-updates.md` for the manual checklist, installation/recovery details and limitations. Existing builds need one initial updater-enabled installation. Linux package-manager distributions are deliberately not overwritten. SHA-256 over GitHub HTTPS provides integrity checking, not independent publisher signing; the existing Windows installer remains unsigned.
